### PR TITLE
Fix #179, Attività di Centrale Operativa

### DIFF
--- a/anagrafica/permessi/funzioni.py
+++ b/anagrafica/permessi/funzioni.py
@@ -40,9 +40,10 @@ def permessi_persona(persona):
         Partecipazione.con_esito(Partecipazione.ESITO_OK,
                                  persona=persona,
                                  ).via("attivita__turni__partecipazioni"),
-        attivita__turni__inizio__lte=
+        attivita__turni__inizio__lte=tra_quindici_minuti,
+        attivita__turni__fine__gte=quindici_minuti_fa,
         attivita__centrale_operativa=True,
-    ).espandi(includi_me=True)
+    )
 
     return [
         (GESTIONE_CENTRALE_OPERATIVA_SEDE, sede_centrale_operativa)

--- a/anagrafica/permessi/persona.py
+++ b/anagrafica/permessi/persona.py
@@ -142,7 +142,7 @@ def persona_ha_permesso(persona, permesso, al_giorno=None):
 
     # Permessi derivanti dalla persona
     for (p, o) in permessi_persona(persona):
-        if p == permesso:
+        if p == permesso and o.exists():
             return True
 
     # Permessi derivanti dalle deleghe

--- a/attivita/forms.py
+++ b/attivita/forms.py
@@ -19,7 +19,7 @@ class ModuloStoricoTurni(forms.Form):
 class ModuloAttivitaInformazioni(ModelForm):
     class Meta:
         model = Attivita
-        fields = [ 'stato', 'apertura', 'estensione', 'descrizione', ]
+        fields = ['stato', 'apertura', 'estensione', 'descrizione', 'centrale_operativa']
         widgets = {
             "descrizione": WYSIWYGSemplice(),
         }

--- a/attivita/migrations/0010_attivita_centrale_operativa.py
+++ b/attivita/migrations/0010_attivita_centrale_operativa.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('attivita', '0009_auto_20160129_0109'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='attivita',
+            name='centrale_operativa',
+            field=models.BooleanField(verbose_name='Attività di Centrale Operativa', default=False, db_index=True, help_text="Selezionando questa opzione, i partecipanti confermati verranno abilitati all'uso del pannello di Centrale Operativa della Sede da 15 minuti prima dell'inizio a 15 minuti dopo la fine del turno."),
+        ),
+    ]

--- a/attivita/models.py
+++ b/attivita/models.py
@@ -51,6 +51,10 @@ class Attivita(ModelloSemplice, ConGeolocalizzazione, ConMarcaTemporale, ConGiud
         (APERTA, 'Aperta')
     )
 
+    # Numero di minuti di grazie per i turni delle
+    # attività di Centrale Operativa
+    MINUTI_CENTRALE_OPERATIVA = 15
+
     nome = models.CharField(max_length=255, default="Nuova attività", db_index=True,
                             help_text="es. Aggiungi un posto a tavola")
     sede = models.ForeignKey('anagrafica.Sede', related_name='attivita', on_delete=models.PROTECT)
@@ -59,6 +63,13 @@ class Attivita(ModelloSemplice, ConGeolocalizzazione, ConMarcaTemporale, ConGiud
     stato = models.CharField(choices=STATO, default=BOZZA, max_length=1, db_index=True)
     apertura = models.CharField(choices=APERTURA, default=APERTA, max_length=1, db_index=True)
     descrizione = models.TextField(blank=True)
+
+    centrale_operativa = models.BooleanField(verbose_name="Attività di Centrale Operativa", default=False,
+                                             help_text="Selezionando questa opzione, i partecipanti confermati verranno "
+                                                       "abilitati all'uso del pannello di Centrale Operativa della Sede "
+                                                       "da %d minuti prima dell'inizio a %d minuti dopo la fine del "
+                                                       "turno." % (MINUTI_CENTRALE_OPERATIVA, MINUTI_CENTRALE_OPERATIVA),
+                                             db_index=True)
 
     def __str__(self):
         return self.nome

--- a/base/utils_tests.py
+++ b/base/utils_tests.py
@@ -1,12 +1,14 @@
 import random
 import string
+from datetime import timedelta
 
 import names
 
 from anagrafica.costanti import LOCALE, ESTENSIONE
 from anagrafica.models import Persona, Sede, Appartenenza, Delega
 from anagrafica.permessi.applicazioni import PRESIDENTE
-from attivita.models import Area
+from attivita.models import Area, Attivita, Turno, Partecipazione
+from base.utils import poco_fa
 
 
 def codice_fiscale(length=16):
@@ -69,3 +71,52 @@ def crea_area(sede):
     area.save()
     return area
 
+
+def crea_attivita(sede, area, nome="Attivita di test",
+                  stato=Attivita.APERTA, descrizione="Descrizione",
+                  centrale_operativa=False):
+    attivita = Attivita(
+        sede=sede,
+        area=area,
+        estensione=sede,
+        nome=nome,
+        stato=stato,
+        descrizione=descrizione,
+        centrale_operativa=centrale_operativa,
+    )
+    attivita.save()
+    return attivita
+
+
+def crea_area_attivita(sede, centrale_operativa=False):
+    area = crea_area(sede)
+    attivita = crea_attivita(sede, area, centrale_operativa=centrale_operativa)
+    return area, attivita
+
+
+def crea_turno(attivita, inizio=None, fine=None, prenotazione=None,
+               minimo=1, massimo=10):
+    inizio = inizio or poco_fa()
+    fine = fine or poco_fa() + timedelta(hours=2)
+    prenotazione = prenotazione or inizio - timedelta(hours=1)
+    turno = Turno(
+        attivita=attivita,
+        inizio=inizio,
+        fine=fine,
+        prenotazione=prenotazione,
+        minimo=minimo,
+        massimo=massimo,
+        nome="Turno di test",
+    )
+    turno.save()
+    return turno
+
+
+def crea_partecipazione(persona, turno):
+    p = Partecipazione(
+        turno=turno,
+        persona=persona,
+        stato=Partecipazione.RICHIESTA,
+    )
+    p.save()
+    return p

--- a/centrale_operativa/tests.py
+++ b/centrale_operativa/tests.py
@@ -1,0 +1,100 @@
+from datetime import timedelta
+from django.test import TestCase
+
+from anagrafica.permessi.costanti import GESTIONE_CENTRALE_OPERATIVA_SEDE
+from attivita.models import Attivita
+from django.utils import timezone
+from base.utils_tests import crea_persona_sede_appartenenza, crea_persona, crea_area_attivita, crea_turno, \
+    crea_partecipazione
+
+
+class TestCentraleOperativa(TestCase):
+    def test_poteri_temporanei(self):
+
+        presidente = crea_persona()
+        persona, sede, app = crea_persona_sede_appartenenza(presidente=presidente)
+
+        ora = timezone.now()
+
+        area, attivita = crea_area_attivita(sede)
+
+        self.assertFalse(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona non ha di persé i permessi di gestione della CO"
+        )
+
+        self.assertTrue(
+            presidente.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).first() == sede,
+            "Il presidente ha i permessi di gestione della CO",
+        )
+
+        domani_inizio = ora + timedelta(hours=24)
+        domani_fine = ora + timedelta(hours=25)
+
+        t1 = crea_turno(attivita, inizio=domani_inizio, fine=domani_fine)
+        partecipazione = crea_partecipazione(persona, t1)
+
+        self.assertFalse(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona non ha ancora i permessi di gestione della CO"
+        )
+
+        attivita.centrale_operativa = True
+        attivita.save()
+
+        self.assertFalse(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona non ha ancora i permessi di gestione della CO"
+        )
+
+        t1.inizio = ora
+        t1.fine = ora + timedelta(hours=1)
+        t1.save()
+
+        self.assertTrue(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).first() == sede,
+            "La persona può ora gestire la CO per la Sede"
+        )
+
+        self.assertTrue(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).count() == 1,
+            "La persona può ora gestire la CO per la Sede solamente (non sotto unità)"
+        )
+
+        # Provo che il margine funzioni
+        margine = Attivita.MINUTI_CENTRALE_OPERATIVA - 1
+
+        t1.inizio = ora + timedelta(minutes=margine)
+        t1.fine = ora + timedelta(minutes=2*margine)
+        t1.save()
+
+        self.assertTrue(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona può gestire la CO con un margine di %d minuti in anticipo" % margine,
+        )
+
+        t1.inizio = ora - timedelta(hours=24)
+        t1.fine = ora - timedelta(minutes=margine)
+        t1.save()
+
+        self.assertTrue(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona può gestire la CO con un margine di %d minuti dopo la fine" % margine,
+        )
+
+        t1.inizio = ora - timedelta(hours=24)
+        t1.fine = ora - timedelta(minutes=margine+2)
+        t1.save()
+
+        self.assertFalse(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona non puo gestire la CO se è troppo tardi",
+        )
+
+        # Se la partecipazione viene richiesta...
+        partecipazione.richiedi()
+
+        self.assertFalse(
+            persona.oggetti_permesso(GESTIONE_CENTRALE_OPERATIVA_SEDE).exists(),
+            "La persona non può gestire la CO perché la richiesta non è stata processata"
+        )


### PR DESCRIPTION
Permette di impostare una attività come di centrale operativa, dal pannello di modifica dell'attività.

I volontari facenti turno confermati possono quindi accedere al pannello della centrale operativa in una finestra da 15 minuti prima dell'inizio del turno a 15 minuti dopo la fine del turno.

@CroceRossaItaliana/sviluppo ack
