### PR TITLE
Corretto errore quote

### DIFF
--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -840,12 +840,12 @@ def us_quote_nuova(request, me):
                 appartenenza = volontario.appartenenze_attuali(al_giorno=data_versamento, membro=Appartenenza.VOLONTARIO).first()
                 comitato = appartenenza.sede.comitato if appartenenza else None
 
-                if appartenenza.sede not in sedi:
-                    modulo.add_error('volontario', 'Questo Volontario non è appartenente a una Sede di tua competenza.')
-
-                elif not appartenenza:
+                if not appartenenza:
                     modulo.add_error('data_versamento', 'In questa data, il Volontario non risulta appartenente '
                                                         'alla Sede.')
+
+                elif appartenenza.sede not in sedi:
+                    modulo.add_error('volontario', 'Questo Volontario non è appartenente a una Sede di tua competenza.')
 
                 elif not comitato.locazione:
                     return errore_generico(request, me, titolo="Necessario impostare indirizzo del Comitato",


### PR DESCRIPTION
Corretto un errore in caso di data di appartenenza posteriore alla data di chiusura del tesseramento

L'unico caso in cui suono riuscito a riprodurlo è se il volontario è associato al comitato dopo il termine del tesseramento: in quel caso l'appartenenza è nulla e la condizione non veniva verificata nel codice pre-esistente