### PR TITLE
Model admin readonly fields

### DIFF
--- a/anagrafica/admin.py
+++ b/anagrafica/admin.py
@@ -5,6 +5,8 @@ from anagrafica.models import Persona, Sede, Appartenenza, Delega, Documento, Fo
     Riserva, Dimissione, Telefono
 from autenticazione.models import Utenza
 from base.admin import InlineAutorizzazione
+from gruppi.readonly_admin import ReadonlyAdminMixin
+
 
 RAW_ID_FIELDS_PERSONA = []
 RAW_ID_FIELDS_SEDE = []
@@ -20,20 +22,20 @@ RAW_ID_FIELDS_TELEFONO = ['persona']
 
 
 # Aggiugni al pannello di amministrazione
-class InlineAppartenenzaPersona(admin.TabularInline):
+class InlineAppartenenzaPersona(ReadonlyAdminMixin, admin.TabularInline):
     model = Appartenenza
     raw_id_fields = RAW_ID_FIELDS_APPARTENENZA
     extra = 0
 
 
-class InlineDelegaPersona(admin.TabularInline):
+class InlineDelegaPersona(ReadonlyAdminMixin, admin.TabularInline):
     model = Delega
     raw_id_fields = RAW_ID_FIELDS_DELEGA
     fk_name = 'persona'
     extra = 0
 
 
-class InlineDelegaSede(GenericTabularInline):
+class InlineDelegaSede(ReadonlyAdminMixin, GenericTabularInline):
     model = Delega
     raw_id_fields = RAW_ID_FIELDS_DELEGA
     ct_field = 'oggetto_tipo'
@@ -41,24 +43,24 @@ class InlineDelegaSede(GenericTabularInline):
     extra = 0
 
 
-class InlineDocumentoPersona(admin.TabularInline):
+class InlineDocumentoPersona(ReadonlyAdminMixin, admin.TabularInline):
     model = Documento
     raw_id_fields = RAW_ID_FIELDS_DOCUMENTO
     extra = 0
 
 
-class InlineUtenzaPersona(admin.StackedInline):
+class InlineUtenzaPersona(ReadonlyAdminMixin, admin.StackedInline):
     model = Utenza
     extra = 0
 
 
-class InlineTelefonoPersona(admin.StackedInline):
+class InlineTelefonoPersona(ReadonlyAdminMixin, admin.StackedInline):
     model = Telefono
     extra = 0
 
 
 @admin.register(Persona)
-class AdminPersona(admin.ModelAdmin):
+class AdminPersona(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['nome', 'cognome', 'codice_fiscale', 'utenza__email', 'email_contatto', '=id',]
     list_display = ('nome', 'cognome', 'utenza', 'email_contatto', 'codice_fiscale', 'data_nascita', 'stato',
                     'ultima_modifica', )
@@ -68,7 +70,7 @@ class AdminPersona(admin.ModelAdmin):
 
 
 @admin.register(Sede)
-class AdminSede(MPTTModelAdmin):
+class AdminSede(ReadonlyAdminMixin, MPTTModelAdmin):
     search_fields = ['nome', 'genitore__nome']
     list_display = ('nome', 'genitore', 'tipo', 'estensione', 'creazione', 'ultima_modifica', )
     list_filter = ('tipo', 'estensione', 'creazione', )
@@ -79,7 +81,7 @@ class AdminSede(MPTTModelAdmin):
 # admin.site.register(Appartenenza)
 
 @admin.register(Appartenenza)
-class AdminAppartenenza(admin.ModelAdmin):
+class AdminAppartenenza(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["membro", "persona__nome", "persona__cognome", "persona__codice_fiscale",
                      "persona__utenza__email", "sede__nome"]
     list_display = ("persona", "sede", "attuale", "inizio", "fine", "creazione")
@@ -87,10 +89,9 @@ class AdminAppartenenza(admin.ModelAdmin):
     raw_id_fields = RAW_ID_FIELDS_APPARTENENZA
     inlines = [InlineAutorizzazione]
 
-
 # admin.site.register(Delega)
 @admin.register(Delega)
-class AdminDelega(admin.ModelAdmin):
+class AdminDelega(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["tipo", "persona__nome", "persona__cognome", "persona__codice_fiscale", "tipo", "oggetto_id"]
     list_display = ("tipo", "oggetto", "persona", "inizio", "fine", "attuale")
     list_filter = ("tipo", "inizio", "fine")
@@ -99,7 +100,7 @@ class AdminDelega(admin.ModelAdmin):
 
 # admin.site.register(Documento)
 @admin.register(Documento)
-class AdminDocumento(admin.ModelAdmin):
+class AdminDocumento(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["tipo", "persona__nome", "persona__cognome", "persona__codice_fiscale"]
     list_display = ("tipo", "persona", "creazione")
     list_filter = ("tipo", "creazione")
@@ -108,7 +109,7 @@ class AdminDocumento(admin.ModelAdmin):
 
 # admin.site.register(Fototessera)
 @admin.register(Fototessera)
-class AdminFototessera(admin.ModelAdmin):
+class AdminFototessera(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale"]
     list_display = ("persona", "creazione", "esito")
     list_filter = ("creazione",)
@@ -119,7 +120,7 @@ class AdminFototessera(admin.ModelAdmin):
 
 # admin.site.register(Estensione)
 @admin.register(Estensione)
-class AdminEstensione(admin.ModelAdmin):
+class AdminEstensione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale", "destinazione__nome"]
     list_display = ("persona", "destinazione", "richiedente", )
     list_filter = ("confermata", "ritirata", "creazione",)
@@ -129,7 +130,7 @@ class AdminEstensione(admin.ModelAdmin):
 
 # admin.site.register(Trasferimento)
 @admin.register(Trasferimento)
-class AdminTrasferimento(admin.ModelAdmin):
+class AdminTrasferimento(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome",  "persona__codice_fiscale", "destinazione__nome"]
     list_display = ("persona", "destinazione", "creazione", )
     list_filter = ("creazione", "confermata", "ritirata",)
@@ -139,7 +140,7 @@ class AdminTrasferimento(admin.ModelAdmin):
 
 # admin.site.register(Riserva)
 @admin.register(Riserva)
-class AdminRiserva(admin.ModelAdmin):
+class AdminRiserva(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale"]
     list_display = ("persona",)
     list_filter = ("confermata", "ritirata", "creazione",)
@@ -149,7 +150,7 @@ class AdminRiserva(admin.ModelAdmin):
 
 # admin.site.register(Riserva)
 @admin.register(Dimissione)
-class AdminDimissione(admin.ModelAdmin):
+class AdminDimissione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale"]
     list_display = ("persona", "richiedente")
     list_filter = ("creazione",)
@@ -158,7 +159,7 @@ class AdminDimissione(admin.ModelAdmin):
 
 
 @admin.register(Telefono)
-class AdminTelefono(admin.ModelAdmin):
+class AdminTelefono(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale"]
     list_display = ("persona", "numero", "servizio", "creazione",)
     list_filter = ("servizio", "creazione",)

--- a/articoli/admin.py
+++ b/articoli/admin.py
@@ -4,15 +4,16 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 
 from articoli.models import Articolo, ArticoloSegmento
 from base.models import Allegato
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 
-class ArticoloSegmentoInline(admin.TabularInline):
+class ArticoloSegmentoInline(ReadonlyAdminMixin, admin.TabularInline):
     model = ArticoloSegmento
     extra = 1
     raw_id_fields = ('sede', 'titolo')
 
 
-class ArticoloAdminForm(forms.ModelForm):
+class ArticoloAdminForm(ReadonlyAdminMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ArticoloAdminForm, self).__init__(*args, **kwargs)
@@ -24,7 +25,7 @@ class ArticoloAdminForm(forms.ModelForm):
         fields = '__all__'
 
 
-class AllegatoInline(GenericTabularInline):
+class AllegatoInline(ReadonlyAdminMixin, GenericTabularInline):
     model = Allegato
     extra = 2
     ct_field = 'oggetto_tipo'
@@ -32,7 +33,7 @@ class AllegatoInline(GenericTabularInline):
 
 
 @admin.register(Articolo)
-class AdminArticolo(admin.ModelAdmin):
+class AdminArticolo(ReadonlyAdminMixin, admin.ModelAdmin):
     form = ArticoloAdminForm
     inlines = (ArticoloSegmentoInline, AllegatoInline)
     readonly_fields = ('visualizzazioni',)

--- a/attivita/admin.py
+++ b/attivita/admin.py
@@ -1,18 +1,20 @@
 from django.contrib import admin
 from attivita.models import Partecipazione, Turno, Area, Attivita
 from base.admin import InlineAutorizzazione
+from gruppi.readonly_admin import ReadonlyAdminMixin
+
 
 __author__ = 'alfioemanuele'
 
 @admin.register(Attivita)
-class AdminAttivita(admin.ModelAdmin):
+class AdminAttivita(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['nome', 'sede__nome', 'estensione__nome', 'area__nome']
     list_display = ('nome', 'sede', 'area', 'estensione', 'stato', 'apertura')
     list_filter = ('creazione', 'stato', 'apertura')
     raw_id_fields = ('locazione', 'sede', 'estensione', 'area', )
 
 @admin.register(Area)
-class AdminArea(admin.ModelAdmin):
+class AdminArea(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['nome', 'sede__nome', 'obiettivo']
     list_display = ('nome', 'sede', 'obiettivo', 'creazione')
     list_filter = ('creazione', 'obiettivo')
@@ -20,7 +22,7 @@ class AdminArea(admin.ModelAdmin):
 
 
 @admin.register(Turno)
-class AdminTurno(admin.ModelAdmin):
+class AdminTurno(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['nome', 'attivita__nome', 'attivita__sede__nome',]
     list_display = ('nome', 'attivita', 'inizio', 'fine', 'creazione', )
     list_filter = ('inizio', 'fine', 'creazione',)
@@ -28,7 +30,7 @@ class AdminTurno(admin.ModelAdmin):
 
 
 @admin.register(Partecipazione)
-class AdminPartecipazione(admin.ModelAdmin):
+class AdminPartecipazione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['persona__codice_fiscale', 'persona__cognome', 'persona__nome', 'turno__nome', 'turno__attivita__nome',]
     list_display = ('turno', 'persona', 'creazione', 'esito',)
     list_filter = ('creazione', 'stato', 'confermata',)

--- a/base/admin.py
+++ b/base/admin.py
@@ -3,6 +3,8 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 
 from base.geo import Locazione
 from base.models import Autorizzazione, Token, Allegato
+from gruppi.readonly_admin import ReadonlyAdminMixin
+
 
 # Aggiugni al pannello di amministrazione
 admin.site.register(Token)
@@ -13,7 +15,7 @@ def locazione_aggiorna(modello, request, queryset):
 locazione_aggiorna.short_description = "Aggiorna indirizzi selezionati"
 
 
-class InlineAutorizzazione(GenericTabularInline):
+class InlineAutorizzazione(ReadonlyAdminMixin, GenericTabularInline):
     model = Autorizzazione
     raw_id_fields = ["richiedente", "firmatario"]
     ct_field = 'oggetto_tipo'
@@ -22,7 +24,7 @@ class InlineAutorizzazione(GenericTabularInline):
 
 
 @admin.register(Locazione)
-class AdminLocazione(admin.ModelAdmin):
+class AdminLocazione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["=id", "indirizzo", "via", "comune", "regione", "provincia"]
     list_display = ("indirizzo", "provincia", "regione", "stato", "creazione",)
     list_filter = ("regione", "stato", "creazione")
@@ -30,7 +32,7 @@ class AdminLocazione(admin.ModelAdmin):
 
 
 @admin.register(Autorizzazione)
-class AdminAutorizzazione(admin.ModelAdmin):
+class AdminAutorizzazione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["richiedente__nome", "richiedente__cognome", "richiedente__codice_fiscale",
                      "firmatario__nome", "firmatario__cognome", "firmatario__codice_fiscale", ]
     list_display = ("richiedente", "firmatario", "concessa", "necessaria", "progressivo",
@@ -41,7 +43,7 @@ class AdminAutorizzazione(admin.ModelAdmin):
 
 
 @admin.register(Allegato)
-class AdminAllegato(admin.ModelAdmin):
+class AdminAllegato(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["nome"]
     list_display = ["nome", "creazione", "file"]
     list_filter = ("creazione",)

--- a/curriculum/admin.py
+++ b/curriculum/admin.py
@@ -3,17 +3,18 @@ from django.contrib import admin
 from base.admin import InlineAutorizzazione
 from curriculum.models import TitoloPersonale
 from curriculum.models import Titolo
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 
 @admin.register(Titolo)
-class AdminTitolo(admin.ModelAdmin):
+class AdminTitolo(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["nome", ]
     list_display = ("nome", "tipo", "inseribile_in_autonomia",)
     list_filter = ("tipo", "richiede_conferma", "inseribile_in_autonomia",)
 
 
 @admin.register(TitoloPersonale)
-class AdminTitoloPersonale(admin.ModelAdmin):
+class AdminTitoloPersonale(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["titolo__nome", "persona__nome", "persona__cognome", "persona__codice_fiscale", ]
     list_display = ("titolo", "persona", "data_ottenimento", "creazione", "certificato",)
     list_filter = ("titolo__tipo", "creazione", "data_ottenimento",)

--- a/formazione/admin.py
+++ b/formazione/admin.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 
 from base.admin import InlineAutorizzazione
 from formazione.models import CorsoBase, PartecipazioneCorsoBase, AssenzaCorsoBase, Aspirante, LezioneCorsoBase
+from gruppi.readonly_admin import ReadonlyAdminMixin
+
 
 __author__ = 'alfioemanuele'
 
@@ -12,19 +14,19 @@ RAW_ID_FIELDS_ASSENZACORSOBASE = ['lezione', 'persona', 'registrata_da',]
 RAW_ID_FIELDS_ASPIRANTE = ['persona', 'locazione',]
 
 
-class InlinePartecipazioneCorsoBase(admin.TabularInline):
+class InlinePartecipazioneCorsoBase(ReadonlyAdminMixin, admin.TabularInline):
     model = PartecipazioneCorsoBase
     raw_id_fields = RAW_ID_FIELDS_PARTECIPAZIONECORSOBASE
     extra = 0
 
 
-class InlineLezioneCorsoBase(admin.TabularInline):
+class InlineLezioneCorsoBase(ReadonlyAdminMixin, admin.TabularInline):
     model = LezioneCorsoBase
     raw_id_fields = RAW_ID_FIELDS_LEZIONECORSOBASE
     extra = 0
 
 
-class InlineAssenzaCorsoBase(admin.TabularInline):
+class InlineAssenzaCorsoBase(ReadonlyAdminMixin, admin.TabularInline):
     model = AssenzaCorsoBase
     raw_id_fields = RAW_ID_FIELDS_ASSENZACORSOBASE
     extra = 0
@@ -39,7 +41,7 @@ admin_corsi_base_attivi_invia_messaggi.short_description = "(Solo corsi attivi) 
 
 
 @admin.register(CorsoBase)
-class AdminCorsoBase(admin.ModelAdmin):
+class AdminCorsoBase(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['sede__nome', 'sede__genitore__nome', 'progressivo', 'anno', ]
     list_display = ['progressivo', 'anno', 'stato', 'sede', 'data_inizio', 'data_esame', ]
     list_filter = ['anno', 'creazione', 'stato', 'data_inizio', ]
@@ -49,7 +51,7 @@ class AdminCorsoBase(admin.ModelAdmin):
 
 
 @admin.register(PartecipazioneCorsoBase)
-class AdminPartecipazioneCorsoBase(admin.ModelAdmin):
+class AdminPartecipazioneCorsoBase(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['persona__nome', 'persona__cognome', 'persona__codice_fiscale', 'corso__progressivo', ]
     list_display = ['persona', 'corso', 'esito', 'creazione', ]
     raw_id_fields = RAW_ID_FIELDS_PARTECIPAZIONECORSOBASE
@@ -57,7 +59,7 @@ class AdminPartecipazioneCorsoBase(admin.ModelAdmin):
 
 
 @admin.register(LezioneCorsoBase)
-class AdminLezioneCorsoBase(admin.ModelAdmin):
+class AdminLezioneCorsoBase(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['nome', 'corso__progressivo', 'corso__sede__nome', ]
     list_display = ['corso', 'nome', 'inizio', 'fine', ]
     raw_id_fields = RAW_ID_FIELDS_LEZIONECORSOBASE
@@ -65,7 +67,7 @@ class AdminLezioneCorsoBase(admin.ModelAdmin):
 
 
 @admin.register(AssenzaCorsoBase)
-class AdminAssenzaCorsoBase(admin.ModelAdmin):
+class AdminAssenzaCorsoBase(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['persona__nome', 'persona__cognome', 'persona__codice_fiscale', 'lezione__corso__progressivo',
                      'lezione__corso__sede__nome']
     list_display = ['persona', 'lezione', 'creazione', ]
@@ -78,7 +80,7 @@ def ricalcola_raggio(modeladmin, request, queryset):
 ricalcola_raggio.short_description = "Ricalcola il raggio per gli aspiranti selezionati"
 
 @admin.register(Aspirante)
-class AdminAspirante(admin.ModelAdmin):
+class AdminAspirante(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['persona__nome', 'persona__cognome', 'persona__codice_fiscale']
     list_display = ['persona', 'creazione', ]
     raw_id_fields = RAW_ID_FIELDS_ASPIRANTE

--- a/gruppi/admin.py
+++ b/gruppi/admin.py
@@ -1,7 +1,15 @@
 from django.contrib import admin
 from gruppi.models import Appartenenza, Gruppo
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 __author__ = 'alfioemanuele'
 
-admin.site.register(Gruppo)
-admin.site.register(Appartenenza)
+
+class AdminGruppo(ReadonlyAdminMixin, admin.ModelAdmin):
+    pass
+
+class AdminAppartenenza(ReadonlyAdminMixin, admin.ModelAdmin):
+    pass
+
+admin.site.register(Gruppo, AdminGruppo)
+admin.site.register(Appartenenza, AdminAppartenenza)

--- a/gruppi/readonly_admin.py
+++ b/gruppi/readonly_admin.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+class ReadonlyAdminMixin(object):
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.groups.filter(name=settings.READONLY_GROUP).exists():
+            return list(set(
+                [field.name for field in self.opts.local_fields] +
+                [field.name for field in self.opts.local_many_to_many]
+            ))
+        else:
+            return self.readonly_fields

--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -285,5 +285,7 @@ FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS = True
 NORECAPTCHA_SITE_KEY = APIS_CONF.get('nocaptcha', 'site_key', fallback=os.environ.get('NORECAPTCHA_SECRET_KEY'))
 NORECAPTCHA_SECRET_KEY = APIS_CONF.get('nocaptcha', 'secret_key', fallback=os.environ.get('NORECAPTCHA_SITE_KEY'))
 
+READONLY_GROUP = 'anagrafica_readonly'
+
 if os.environ.get('ENABLE_TEST_APPS', False):
     INSTALLED_APPS.append('segmenti.segmenti_test')

--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -214,7 +214,7 @@ DESTINATARI_REPORT = ['sviluppo@cri.it', 'info@gaia.cri.it']
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             "context_processors": (

--- a/patenti/admin.py
+++ b/patenti/admin.py
@@ -1,7 +1,15 @@
 from django.contrib import admin
 from patenti.models import Elemento, Patente
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 __author__ = 'alfioemanuele'
 
-admin.site.register(Patente)
-admin.site.register(Elemento)
+
+class AdminPatente(ReadonlyAdminMixin, admin.ModelAdmin):
+    pass
+
+class AdminElemento(ReadonlyAdminMixin, admin.ModelAdmin):
+    pass
+
+admin.site.register(Patente, AdminPatente)
+admin.site.register(Elemento, AdminElemento)

--- a/posta/admin.py
+++ b/posta/admin.py
@@ -1,12 +1,13 @@
 from django.contrib import admin
 from posta.models import Messaggio
 from posta.models import Destinatario
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 __author__ = 'alfioemanuele'
 
 
 @admin.register(Messaggio)
-class AdminMessaggio(admin.ModelAdmin):
+class AdminMessaggio(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['oggetto', 'mittente__codice_fiscale', 'mittente__email_contatto', 'mittente__utenza__email']
     list_display = ('oggetto', 'mittente', 'creazione', 'ultimo_tentativo', 'terminato', )
     list_filter = ('creazione', 'terminato', 'ultimo_tentativo',)
@@ -14,7 +15,7 @@ class AdminMessaggio(admin.ModelAdmin):
 
 
 @admin.register(Destinatario)
-class AdminDestinatario(admin.ModelAdmin):
+class AdminDestinatario(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ['messaggio__oggetto', 'persona__codice_fiscale', 'persona__email_contatto',
                      'persona__utenza__email', 'errore',]
     list_display = ('messaggio', 'persona', 'inviato', 'tentativo', 'errore')

--- a/social/admin.py
+++ b/social/admin.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 
 from social.models import Commento
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 
 @admin.register(Commento)
-class AdminCommento(admin.ModelAdmin):
+class AdminCommento(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ['autore', 'commento', 'creazione', ]
     list_filter = ['creazione', ]
     search_fields = ['autore__nome', 'autore__cognome', 'autore__codice_fiscale']

--- a/templates/admin/change_form.html
+++ b/templates/admin/change_form.html
@@ -71,6 +71,8 @@
 
 {% if has_add_permission %}
     {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+{% else %}
+    <a href="../../">Indietro</a>
 {% endif %}
 
 {% block admin_change_form_document_ready %}

--- a/templates/admin/change_form.html
+++ b/templates/admin/change_form.html
@@ -1,0 +1,110 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls admin_static admin_modify %}
+
+{% block extrahead %}{{ block.super }}
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+{{ media }}
+{% endblock %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
+
+{% block coltype %}colM{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; {% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+&rsaquo; {% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}<div id="content-main">
+{% block object-tools %}
+{% if change %}{% if not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+    <li>
+        {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+        <a href="{% add_preserved_filters history_url %}" class="historylink">{% trans "History" %}</a>
+    </li>
+    {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif %}
+    {% endblock %}
+  </ul>
+{% endif %}{% endif %}
+{% endblock %}
+<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
+<div>
+{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
+{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}" />{% endif %}
+
+{% if has_add_permission %}
+    {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
+{% endif %}
+
+{% if errors %}
+    <p class="errornote">
+    {% if errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+    </p>
+    {{ adminform.form.non_field_errors }}
+{% endif %}
+
+{% block field_sets %}
+{% for fieldset in adminform %}
+  {% include "admin/includes/fieldset.html" %}
+{% endfor %}
+{% endblock %}
+
+{% block after_field_sets %}{% endblock %}
+
+{% block inline_field_sets %}
+{% for inline_admin_formset in inline_admin_formsets %}
+    {% include inline_admin_formset.opts.template %}
+{% endfor %}
+{% endblock %}
+
+{% block after_related_objects %}{% endblock %}
+
+{% if has_add_permission %}
+    {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+{% endif %}
+
+{% block admin_change_form_document_ready %}
+    <script type="text/javascript">
+        (function($) {
+            $(document).ready(function() {
+                $('.add-another').click(function(e) {
+                    e.preventDefault();
+                    var event = $.Event('django:add-another-related');
+                    $(this).trigger(event);
+                    if (!event.isDefaultPrevented()) {
+                        showAddAnotherPopup(this);
+                    }
+                });
+                $('.related-lookup').click(function(e) {
+                    e.preventDefault();
+                    var event = $.Event('django:lookup-related');
+                    $(this).trigger(event);
+                    if (!event.isDefaultPrevented()) {
+                        showRelatedObjectLookupPopup(this);
+                    }
+                });
+
+            {% if adminform and add %}
+                $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()
+            {% endif %}
+            });
+        })(django.jQuery);
+    </script>
+{% endblock %}
+
+{# JavaScript for prepopulated fields #}
+{% prepopulated_fields_js %}
+
+</div>
+</form></div>
+{% endblock %}

--- a/ufficio_soci/admin.py
+++ b/ufficio_soci/admin.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 from ufficio_soci.models import Tesserino, Quota, Tesseramento
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 __author__ = 'alfioemanuele'
 
 
 @admin.register(Quota)
-class AdminQuota(admin.ModelAdmin):
+class AdminQuota(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale",
                      "sede__nome", ]
     list_display = ("persona", "tipo", "stato", "sede", "progressivo", "anno", "data_versamento",)
@@ -14,7 +15,7 @@ class AdminQuota(admin.ModelAdmin):
 
 
 @admin.register(Tesserino)
-class AdminTesserino(admin.ModelAdmin):
+class AdminTesserino(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale",
                      "codice", ]
     list_display = ("codice", "persona", "valido", "tipo_richiesta", "stato_richiesta", "stato_emissione",)
@@ -23,7 +24,7 @@ class AdminTesserino(admin.ModelAdmin):
 
 
 @admin.register(Tesseramento)
-class AdminTesseramento(admin.ModelAdmin):
+class AdminTesseramento(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["anno", ]
     list_display = ("anno", "stato", "inizio", "quota_attivo", "quota_ordinario", "quota_sostenitore",
                     "quota_benemerito", "quota_aspirante",)

--- a/veicoli/admin.py
+++ b/veicoli/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from veicoli.models import Autoparco, Veicolo, FermoTecnico, Manutenzione, Segnalazione, Collocazione, \
     Rifornimento
+from gruppi.readonly_admin import ReadonlyAdminMixin
 
 __author__ = 'alfioemanuele'
 
@@ -9,7 +10,7 @@ __author__ = 'alfioemanuele'
 
 
 @admin.register(Autoparco)
-class AdminAutoparco(admin.ModelAdmin):
+class AdminAutoparco(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["nome", "sede__nome", ]
     list_display = ("nome", "sede", "telefono", "locazione",)
     list_filter = ("creazione",)
@@ -17,14 +18,14 @@ class AdminAutoparco(admin.ModelAdmin):
 
 
 @admin.register(Veicolo)
-class AdminVeicolo(admin.ModelAdmin):
+class AdminVeicolo(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["targa", "libretto", "telaio", ]
     list_display = ("targa", "libretto", "telaio", "marca", "modello",)
     list_filter = ("stato",)
 
 
 @admin.register(FermoTecnico)
-class AdminFermoTecnico(admin.ModelAdmin):
+class AdminFermoTecnico(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["veicolo__targa", ]
     list_display = ("veicolo", "inizio", "fine", "attuale", "motivo",)
     list_filter = ("creazione", "inizio", "fine",)
@@ -32,7 +33,7 @@ class AdminFermoTecnico(admin.ModelAdmin):
 
 
 @admin.register(Collocazione)
-class AdminCollocazione(admin.ModelAdmin):
+class AdminCollocazione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["veicolo__targa", "autoparco__nome", "autoparco__sede__nome", ]
     list_display = ("veicolo", "autoparco", "inizio", "fine", "attuale",)
     list_filter = ("fine", "inizio",)
@@ -40,7 +41,7 @@ class AdminCollocazione(admin.ModelAdmin):
 
 
 @admin.register(Rifornimento)
-class AdminRifornimento(admin.ModelAdmin):
+class AdminRifornimento(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["veicolo__targa", ]
     list_display = ("veicolo", "data", "creazione",)
     list_filter = ("data",)
@@ -48,7 +49,7 @@ class AdminRifornimento(admin.ModelAdmin):
 
 
 @admin.register(Manutenzione)
-class AdminManutenzione(admin.ModelAdmin):
+class AdminManutenzione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["veicolo__targa", ]
     list_display = ("veicolo", "tipo", "data", "creato_da",)
     list_filter = ("tipo",)


### PR DESCRIPTION
Fix: #290
Aggiunge un model admin mixin per impostare tutti i campi in readonly agli utenti appartenenti ad un certo gruppo. Il gruppo è settabile nei settings.

Per testarla creare un gruppo con nome di default impostato nei settings: anagrafica_readonly al quale associare gli utenti con permessi Attivo e Amministratore. Al gruppo vanno inseriti i permessi di solo 'change' (che poi non si verificherà ma serve solo per visualizzare gli oggetti) anagrafica.