### PR TITLE
Login as delegabile

### DIFF
--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -289,3 +289,6 @@ READONLY_GROUP = 'anagrafica_readonly'
 
 if os.environ.get('ENABLE_TEST_APPS', False):
     INSTALLED_APPS.append('segmenti.segmenti_test')
+
+CAN_LOGIN_AS = lambda request, target_user: request.user.is_superuser or request.user.groups.filter(name='loginas').exists()
+


### PR DESCRIPTION
Permette ad un utente facente parte del gruppo loginas di fare loginas.

Come richiesto nella #350 con questa modifica ai settings di loginas è possibile specificare 
un gruppo da assegnare a quegli utenti che devono fare loginas senza essere superuser.

Per testare creare un gruppo con nome 'loginas' e assegnarlo ad un utente.