### PR TITLE
Remove trusted-host option, unsupported by obsolete pip versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 --extra-index-url https://devpi.iast.it/nephila/public/+simple/
---trusted-host devpi.iast.it
 Django==1.9.4
 Markdown==2.6
 django-bootstrap3==7.0.0


### PR DESCRIPTION
Fix #382 

Non è un'opzione supportata da pip 1.5.4 quella presente almeno sul server di staging
Rimossa perché comunque gestito in altro modo