### PR TITLE
Corretto uso random.randint (che include gli estremi)

### DIFF
--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -1027,7 +1027,7 @@ def verifica_tesserino(request, me=None):
         try:
             tesserino = Tesserino.objects.get(codice=modulo.cleaned_data['numero_tessera'])
             cognome = tesserino.persona.cognome
-            lettera_numero = random.randint(0, len(cognome))
+            lettera_numero = random.randint(0, len(cognome) - 1)
             lettera = cognome[lettera_numero].upper()
             lettera_numero += 1
 


### PR DESCRIPTION
``random.randint`` include anche gli estremi, quindi bisogna usare ``len - 1`` altrimenti ritorna un'eccezione nel caso in cui sia selezionato l'estremo destro
Questo dovrebbe essere la causa dei fallimenti random su travis di ``ufficio_soci.tests.TestFunzionaleUfficioSoci.test_richiedi_tesserino``
Insieme a #412 dovrebbe dare più stabilità a travis