### PR TITLE
Aggiorna pacchetti

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://devpi.iast.it/nephila/public/+simple/
-Django==1.9.4
+Django==1.9.9
 Markdown==2.6
 django-bootstrap3==7.0.0
 django-filter==0.9.2
 django-autoslug==1.9.3
-django-mptt==0.8.3
+django-mptt==0.8.6
 phonenumbers==7.0.2
 Pillow==3.2.0
 django-countries==3.3
@@ -31,9 +31,9 @@ csscompressor==0.9.4
 slimit==0.8.1
 pyBarcode==0.7
 cssselect==0.9.1
-splinter==0.7.3
+splinter==0.7.4
 tblib==1.3.0
-selenium==2.52.0
+selenium==2.53.6
 django-filer==1.2.1a1.dev3
 django-ckeditor-filebrowser-filer==0.2.0b12
 django-nocaptcha-recaptcha==0.0.19


### PR DESCRIPTION
Alcuni aggiornamenti
* Django 1.9.9 è l'ultimo rilascio di sicurezza
* mptt 0.8.6 risolve diversi bachi (teorici)
* selenium / splinter correggono alcuni problemi con diversi selettori (forse causa dei fallimenti random su travis)