### PR TITLE
Rimuovi freezegun

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,3 @@ django-ckeditor-filebrowser-filer==0.2.0b12
 django-nocaptcha-recaptcha==0.0.19
 django-two-factor-auth==1.4.0
 django-otp-yubikey==0.3.4
-freezegun==0.3.7


### PR DESCRIPTION
Apparenemente freezegun non ripristina correttamente lo stato della data al termine del mocking

Fix #438