### PR TITLE
WiP:Aggiunto comando per la riassegnazione dei comitati

### DIFF
--- a/anagrafica/management/__init__.py
+++ b/anagrafica/management/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals

--- a/anagrafica/management/commands/__init__.py
+++ b/anagrafica/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals

--- a/anagrafica/management/commands/riassegna_comitati.py
+++ b/anagrafica/management/commands/riassegna_comitati.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.core.management.base import NoArgsCommand
+from django.db import transaction
+
+from anagrafica.costanti import LOCALE, PROVINCIALE, REGIONALE
+from anagrafica.models import Sede
+
+
+class Command(NoArgsCommand):
+
+    def handle_noargs(self, **options):
+        with transaction.atomic():
+            comitati = Sede.objects.filter(tipo=Sede.COMITATO, estensione=LOCALE)
+            for comitato in comitati:
+                if comitato.genitore.estensione == PROVINCIALE and comitato.genitore.genitore and comitato.genitore.genitore.estensione == REGIONALE:
+                    comitato.genitore = comitato.genitore.genitore
+                    comitato.save()


### PR DESCRIPTION
Fix #338 
E' implementato come comando per evitare che la riassegnazione avvenga per errore durante un deployment