### PR TITLE
Il controllo se già associato alla sede è limitato ai soli volontari

### DIFF
--- a/anagrafica/tests.py
+++ b/anagrafica/tests.py
@@ -20,7 +20,7 @@ from base.utils_tests import crea_persona_sede_appartenenza, crea_persona, crea_
     crea_utenza
 from formazione.models import Aspirante
 from jorvik.settings import GOOGLE_KEY
-from posta.models import Messaggio
+from posta.models import Messaggio, Autorizzazione
 
 
 class TestAnagrafica(TestCase):
@@ -874,6 +874,44 @@ class TestAnagrafica(TestCase):
 
 
 class TestFunzionaliAnagrafica(TestFunzionale):
+
+    def test_sede_trasferimento(self):
+        presidente = crea_persona()
+        persona, sede, appartenenza = crea_persona_sede_appartenenza(presidente=presidente)
+        crea_utenza(persona, email=email_fittizzia())
+        sede_2 = crea_sede(presidente=presidente)
+
+        self.client.login(username=persona.utenza.email, password="prova")
+        dati = {
+            'destinazione': sede_2.pk,
+            'motivo': 'test',
+        }
+        response = self.client.post('/utente/trasferimento/', data=dati)
+        self.assertNotContains(response=response, text='Sei già appartenente a questa sede')
+        self.assertEqual(Autorizzazione.objects.filter(richiedente=persona, concessa=None).count(), 1)
+        Autorizzazione.objects.get(richiedente=persona, concessa=None).nega(presidente)
+
+        Appartenenza.objects.create(
+            persona=persona,
+            sede=sede_2,
+            membro=Appartenenza.ESTESO,
+            inizio="1980-12-10",
+        )
+        response = self.client.post('/utente/trasferimento/', data=dati)
+        self.assertNotContains(response=response, text='Sei già appartenente a questa sede')
+        self.assertEqual(Autorizzazione.objects.filter(richiedente=persona, concessa=None).count(), 1)
+        Autorizzazione.objects.get(richiedente=persona, concessa=None).nega(presidente)
+
+        Appartenenza.objects.create(
+            persona=persona,
+            sede=sede_2,
+            membro=Appartenenza.VOLONTARIO,
+            inizio="1980-12-10",
+        )
+        response = self.client.post('/utente/trasferimento/', data=dati)
+        self.assertContains(response=response, text='Sei già appartenente a questa sede')
+        self.assertEqual(Autorizzazione.objects.filter(richiedente=persona, concessa=None).count(), 0)
+
 
     def test_us_attivazione_credenziali(self):
 

--- a/anagrafica/viste.py
+++ b/anagrafica/viste.py
@@ -954,7 +954,7 @@ def utente_trasferimento(request, me):
     modulo = ModuloCreazioneTrasferimento(request.POST or None)
     if modulo.is_valid():
         trasf = modulo.save(commit=False)
-        if trasf.destinazione in me.sedi_attuali():
+        if trasf.destinazione in me.sedi_attuali(membro=Appartenenza.VOLONTARIO):
             modulo.add_error('destinazione', 'Sei già appartenente a questa sede.')
         #elif trasf.destinazione.comitato != me.sede_riferimento().comitato and True:##che in realta' e' il discriminatore delle elezioni
         #    return errore_generico(request, me, messaggio="Non puoi richiedere un trasferimento tra comitati durante il periodo elettorale")


### PR DESCRIPTION
Fix #217 
Fix #139 

Qui è necessario decidere se filtrare per esclusione (cioè escludendo solo le estensioni) o per inclusione (quindi solo per i volontari)