### PR TITLE
Fix #391, risolve problema campi modifica attivita vuoti

### DIFF
--- a/attivita/viste.py
+++ b/attivita/viste.py
@@ -620,7 +620,7 @@ def attivita_scheda_informazioni_modifica(request, me, pk=None):
     if not me.permessi_almeno(attivita, MODIFICA):
         return redirect(ERRORE_PERMESSI)
 
-    if not me.ha_permesso(GESTIONE_POTERI_CENTRALE_OPERATIVA_SEDE):
+    if request.POST and not me.ha_permesso(GESTIONE_POTERI_CENTRALE_OPERATIVA_SEDE):
         request.POST = request.POST.copy()
         request.POST['centrale_operativa'] = attivita.centrale_operativa
 


### PR DESCRIPTION
Vedi commento in #391.

Risolto problema introdotto in commit 8c98a4bc6ac450ac1f5b71b92113ac91dba73eb0
che causava che il dizionario request.POST fosse pieno anche dove la pagina era
stata appena caricata. Per di piu', il dizioario era pieno solo di un campo
('centrale_operativa') che causava Django a credere che tutti i campi erano
stati riempiti e posti come vuoti.