### PR TITLE
Si può reclamare una persona anche se è sostenitore / dipendente

### DIFF
--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -63,7 +63,10 @@ class PersonaAutocompletamento(AutocompletamentoBase):
     '''
 
     def choice_html(self, choice):
-        app = choice.appartenenze_attuali().first() if choice else None
+        if choice.appartenenze_attuali(membro=Appartenenza.VOLONTARIO).exists():
+            app = choice.appartenenze_attuali(membro=Appartenenza.VOLONTARIO).first()
+        else:
+            app = choice.appartenenze_attuali().first() if choice else None
         return self.choice_html_format % (
             self.choice_value(choice),
             self.choice_label(choice),

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -932,8 +932,8 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
 
     def reclamabile_in_sede(self, sede):
         """
-        Controlla se la persona e' reclamabile come socio presso una
-            determinata sede.
+        Controlla se la persona e' reclamabile come socio presso una determinata sede.
+
         :param sede: Sede presso la quale reclamare il socio
         :return: True o False
         """
@@ -942,6 +942,7 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
 
         regionale = sede.superiore(REGIONALE)
 
+        # I soci ordinari sul proprio regionale possono essere reclamati (ma solo se sono **solo** ordinari)
         if self.appartenenze_attuali().filter(
             sede=regionale,
             membro=Appartenenza.ORDINARIO
@@ -951,7 +952,16 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
         ).exists():
             return True
 
+        # I dipendenti possono essere reclamati (ma solo se sono **solo** dipendenti)
+        if self.appartenenze_attuali().filter(
+            membro=Appartenenza.DIPENDENTE
+        ).exists() and not self.appartenenze_attuali().exclude(
+            membro=Appartenenza.DIPENDENTE
+        ).exists():
+            return True
+
         return False
+
 
     def genera_foglio_di_servizio(self):
         storico = Partecipazione.con_esito_ok().filter(persona=self, stato=Partecipazione.RICHIESTA)\
@@ -2222,21 +2232,30 @@ class Dimissione(ModelloSemplice, ConMarcaTemporale):
     QUOTA = 'QUO'
     RADIAZIONE = 'RAD'
     DECEDUTO = 'DEC'
+    TRASFORMAZIONE = 'TRA'
+    ALTRO = 'ALT'
 
-    MOTIVI = (
+    MOTIVI_VOLONTARI = (
         (VOLONTARIE, 'Dimissioni Volontarie'),
         (TURNO, 'Mancato svolgimento turno'),
         (RISERVA, 'Mancato rientro da riserva'),
         (QUOTA, 'Mancato versamento quota annuale'),
         (RADIAZIONE, 'Radiazione da Croce Rossa Italiana'),
-        (DECEDUTO,  'Decesso'),
+        (DECEDUTO, 'Decesso'),
     )
+
+    MOTIVI_ALTRI = (
+        (TRASFORMAZIONE, 'Trasformazione in volontario'),
+        (ALTRO, 'Altro'),
+    )
+
+    MOTIVI = MOTIVI_VOLONTARI + MOTIVI_ALTRI
 
     motivo = models.CharField(choices=MOTIVI, max_length=3)
     info = models.CharField(max_length=512, help_text="Maggiori informazioni sulla causa della dimissione")
     richiedente = models.ForeignKey(Persona, on_delete=models.SET_NULL, null=True)
 
-    def applica(self, trasforma_in_sostenitore=False):
+    def applica(self, trasforma_in_sostenitore=False, invia_notifica=True):
         from gruppi.models import Appartenenza as App
         precedente_appartenenza = self.appartenenza
         precedente_sede = self.persona.sede_riferimento()
@@ -2249,6 +2268,11 @@ class Dimissione(ModelloSemplice, ConMarcaTemporale):
             presidente = self.persona.comitato_riferimento().presidente()
             destinatari.add(presidente)
 
+        if precedente_appartenenza.membro == Appartenenza.SOSTENITORE:
+            template = "email_dimissioni_sostenitore.html"
+        else:
+            template = "email_dimissioni.html"
+
         Appartenenza.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa(), terminazione=Appartenenza.DIMISSIONE)
         Delega.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
         App.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
@@ -2258,40 +2282,42 @@ class Dimissione(ModelloSemplice, ConMarcaTemporale):
             for y in [Estensione, Trasferimento, Partecipazione, TitoloPersonale]
         ]
 
-        if self.motivo != self.DECEDUTO:
+        if trasforma_in_sostenitore:
+            app = Appartenenza(precedente=precedente_appartenenza, persona=self.persona,
+                               sede=precedente_sede,
+                               inizio=date.today(),
+                               membro=Appartenenza.SOSTENITORE)
+            app.save()
 
-            if trasforma_in_sostenitore:
-                app = Appartenenza(precedente=precedente_appartenenza, persona=self.persona,
-                                   sede=precedente_sede,
-                                   inizio=date.today(),
-                                   membro=Appartenenza.SOSTENITORE)
-                app.save()
+        if invia_notifica:
 
-            Messaggio.costruisci_e_invia(
-                oggetto="Dimissioni",
-                modello="email_dimissioni.html",
-                corpo={
-                    "dimissione": self,
-                },
-                mittente=self.richiedente,
+            if self.motivo == self.DECEDUTO:
 
-                destinatari=[
-                    self.persona
-                ]
-            )
-        else:
+                for destinatario in destinatari:
+                    Messaggio.costruisci_e_invia(
+                        oggetto="Dimissioni per decesso",
+                        modello="email_dimissioni_decesso.html",
+                        corpo={
+                            "dimissione": self,
+                            "destinatario": destinatario,
+                            "carica": "Presidente" if destinatario == presidente else "Delegato Ufficio Soci"
+                        },
+                        mittente=self.richiedente,
+                        destinatari=[destinatario]
+                    )
 
-            for destinatario in destinatari:
+            else:
+
                 Messaggio.costruisci_e_invia(
-                    oggetto="Dimissioni per decesso",
-                    modello="email_dimissioni_decesso.html",
+                    oggetto="Dimissioni",
+                    modello=template,
                     corpo={
                         "dimissione": self,
-                        "destinatario": destinatario,
-                        "carica": "Presidente" if destinatario == presidente else "Delegato Ufficio Soci"
                     },
                     mittente=self.richiedente,
-                    destinatari=[destinatario]
-                )
 
+                    destinatari=[
+                        self.persona
+                    ]
+                )
 

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -2273,14 +2273,17 @@ class Dimissione(ModelloSemplice, ConMarcaTemporale):
         else:
             template = "email_dimissioni.html"
 
-        Appartenenza.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa(), terminazione=Appartenenza.DIMISSIONE)
-        Delega.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
-        App.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
-        #TODO reperibilita'
-        [
-            [x.ritira() for x in y.con_esito_pending().filter(persona=self.persona)]
-            for y in [Estensione, Trasferimento, Partecipazione, TitoloPersonale]
-        ]
+        if precedente_appartenenza.membro == Appartenenza.VOLONTARIO:
+            Delega.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
+            App.query_attuale(al_giorno=self.creazione, persona=self.persona).update(fine=poco_fa())
+            #TODO reperibilita'
+            [
+                [x.ritira() for x in y.con_esito_pending().filter(persona=self.persona)]
+                for y in [Estensione, Trasferimento, Partecipazione, TitoloPersonale]
+            ]
+        Appartenenza.query_attuale(
+            al_giorno=self.creazione, persona=self.persona, membro=precedente_appartenenza.membro
+        ).update(fine=poco_fa(), terminazione=Appartenenza.DIMISSIONE)
 
         if trasforma_in_sostenitore:
             app = Appartenenza(precedente=precedente_appartenenza, persona=self.persona,

--- a/base/menu.py
+++ b/base/menu.py
@@ -156,6 +156,7 @@ def menu(request):
                 ("In Riserva", "fa-list", "/us/elenchi/riserva/"),
                 ("Soci", "fa-list", "/us/elenchi/soci/"),
                 ("Sostenitori", "fa-list", "/us/elenchi/sostenitori/"),
+                ("Ex Sostenitori", "fa-list", "/us/elenchi/ex-sostenitori/"),
                 ("Dipendenti", "fa-list", "/us/elenchi/dipendenti/"),
                 ("Dimessi", "fa-list", "/us/elenchi/dimessi/"),
                 ("Trasferiti", "fa-list", "/us/elenchi/trasferiti/"),

--- a/jorvik/urls.py
+++ b/jorvik/urls.py
@@ -213,6 +213,7 @@ urlpatterns = [
     url(r'^us/riserva/$', ufficio_soci.viste.us_riserva),
     url(r'^us/riserva/(?P<pk>.*)/termina/$', ufficio_soci.viste.us_riserva_termina),
     url(r'^us/dimissioni/(?P<pk>[0-9]+)/$', ufficio_soci.viste.us_dimissioni),
+    url(r'^us/dimissioni/sostenitore/(?P<pk>[0-9]+)/$', ufficio_soci.viste.us_chiudi_sostenitore, name='us-chiudi-sostenitore'),
 
     url(r'^us/elenchi/(?P<elenco_tipo>.*)/$', ufficio_soci.viste.us_elenchi),
     url(r'^us/quote/$', ufficio_soci.viste.us_quote),

--- a/posta/templates/email_dimissioni_sostenitore.html
+++ b/posta/templates/email_dimissioni_sostenitore.html
@@ -1,0 +1,11 @@
+{% extends 'email.html' %}
+
+{% block corpo %}
+
+
+<p class="grassetto">Ciao {{ dimissione.persona.nome_completo }},</p>
+<p>Non sei più sostenitore di Croce Rossa Italiana per <strong>{{ dimissione.get_motivo_display }} {{ dimissione.info }}</strong>.</p>
+<p>Potrai comunque accedere a GAIA e visualizzare i tuoi dati personali.</p>
+<p>Se pensi che ci sia stato un errore, ti invitiamo a rispondere a questa email indicandoci cosa c'è da correggere.</p>
+
+{% endblock %}

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -172,6 +172,10 @@ class ModuloCreazioneDimissioni(ModelForm):
     trasforma_in_sostenitore = forms.BooleanField(help_text="In caso di Dimissioni Volontarie seleziona quest'opzione "
                                                             "per trasformare il volontario in sostenitore. ", required=False)
 
+    def __init__(self, *args, **kwargs):
+        super(ModuloCreazioneDimissioni, self).__init__(*args, **kwargs)
+        self.fields['motivo'].choices = (("", "---------"),) + Dimissione.MOTIVI_VOLONTARI
+
     def clean_trasforma_in_sostenitore(self):
         trasforma_in_sostenitore = self.cleaned_data['trasforma_in_sostenitore']
         motivo = self.cleaned_data['motivo']
@@ -179,6 +183,16 @@ class ModuloCreazioneDimissioni(ModelForm):
             raise ValidationError("Puoi richiedere la trasformazione in sostenitore solo in "
                                   "caso di dimissioni volontarie.")
         return trasforma_in_sostenitore
+
+
+class ModuloDimissioniSostenitore(ModelForm):
+    class Meta:
+        model = Dimissione
+        fields = ['motivo', 'info', ]
+
+    def __init__(self, *args, **kwargs):
+        super(ModuloDimissioniSostenitore, self).__init__(*args, **kwargs)
+        self.fields['motivo'].choices = (("", "---------"),) + Dimissione.MOTIVI_ALTRI
 
 
 class ModuloElencoRicevute(forms.Form):

--- a/ufficio_soci/templates/us_elenchi_inc_sostenitori.html
+++ b/ufficio_soci/templates/us_elenchi_inc_sostenitori.html
@@ -2,7 +2,6 @@
 
 
 {% block elenco_intestazione_extra %}
-    <th>Sede</th>
 {% endblock %}
 
 {% block elenco_riga_azioni_extra %}

--- a/ufficio_soci/templates/us_elenchi_inc_sostenitori.html
+++ b/ufficio_soci/templates/us_elenchi_inc_sostenitori.html
@@ -1,0 +1,17 @@
+{% extends 'us_elenchi_inc_persone.html' %}
+
+
+{% block elenco_intestazione_extra %}
+    <th>Sede</th>
+{% endblock %}
+
+{% block elenco_riga_azioni_extra %}
+
+    {% if puo_modificare %}
+        <a class="btn btn-default" href="/us/dimissioni/sostenitore/{{ persona.pk }}/" target="_new">
+            <i class="fa fa-fw fa-times"></i> Dimetti
+        </a>
+
+    {% endif %}
+
+{% endblock %}

--- a/ufficio_soci/templates/us_reclama.html
+++ b/ufficio_soci/templates/us_reclama.html
@@ -46,8 +46,13 @@
                 <ul>
                     <li>Non è appartenente ad alcun Comitato;</li>
                     <li>&Egrave; un socio ordinario appartenente al Comitato Regionale.</li>
+                    <li>E' registrato come dipendente CRI</li>
 
                 </ul>
+            <p>
+                Nel caso di sostenitore, è possibile reclamarli, ma è prima necessario dimetterli dalla loro posizione attuale.<br>
+                Per farlo puoi andare nell'elenco <b>Sostenitori</b> e selezionare <i>Dimetti</i> accanto al suo nome
+            </p>
             <p>&nbsp;</p>
 
             <h4><i class="fa fa-fw fa-support"></i> Guida alla compilazione</h4>

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -10,14 +10,14 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from anagrafica.costanti import NAZIONALE, PROVINCIALE, REGIONALE
-from anagrafica.models import Appartenenza, Sede, Persona, Fototessera
+from anagrafica.models import Appartenenza, Sede, Persona, Fototessera, Dimissione
 from anagrafica.permessi.applicazioni import UFFICIO_SOCI
 from autenticazione.utils_test import TestFunzionale
 from base.geo import Locazione
 from base.utils import poco_fa
 from base.utils_tests import crea_persona_sede_appartenenza, crea_persona, crea_sede, crea_appartenenza, \
-    crea_utenza, crea_locazione
-from ufficio_soci.elenchi import ElencoElettoratoAlGiorno
+    crea_utenza, crea_locazione, email_fittizzia
+from ufficio_soci.elenchi import ElencoElettoratoAlGiorno, ElencoSociAlGiorno, ElencoSostenitori, ElencoExSostenitori
 from ufficio_soci.forms import ModuloElencoElettorato, ModuloReclamaQuota
 from ufficio_soci.models import Tesseramento, Tesserino, Quota, Riduzione
 
@@ -260,6 +260,57 @@ class TestBase(TestCase):
         self.a.save()
         x.delete()
 
+    def test_dimissione_sostenitore(self):
+
+        presidente = crea_persona()
+        crea_utenza(presidente, email=email_fittizzia())
+        sostenitore1, sede, a = crea_persona_sede_appartenenza(presidente)
+        a.membro = Appartenenza.SOSTENITORE
+        a.save()
+        socio1 = crea_persona()
+        Appartenenza.objects.create(persona=socio1, sede=sede, inizio=poco_fa(), membro=Appartenenza.VOLONTARIO)
+        sostenitore2 = crea_persona()
+        Appartenenza.objects.create(persona=sostenitore2, sede=sede, inizio=poco_fa(), membro=Appartenenza.SOSTENITORE)
+        socio2 = crea_persona()
+        Appartenenza.objects.create(persona=socio2, sede=sede, inizio=poco_fa(), membro=Appartenenza.VOLONTARIO)
+
+        elenco = ElencoSostenitori([sede])
+        sostenitori = elenco.risultati()
+        self.assertTrue(sostenitore1 in sostenitori)
+        self.assertTrue(sostenitore2 in sostenitori)
+        self.assertTrue(socio1 not in sostenitori)
+        self.assertTrue(socio2 not in sostenitori)
+
+        self.client.login(username=presidente.utenza.email, password='prova')
+        data = {
+            'info': 'bla bla',
+            'motivo': Dimissione.ALTRO
+        }
+        self.client.post(reverse('us-chiudi-sostenitore', args=(sostenitore1.pk,)), data=data)
+
+        elenco = ElencoSostenitori([sede])
+        sostenitori = elenco.risultati()
+        self.assertTrue(sostenitore1 not in sostenitori)
+        self.assertTrue(sostenitore2 in sostenitori)
+        self.assertTrue(socio1 not in sostenitori)
+        self.assertTrue(socio2 not in sostenitori)
+
+        elenco = ElencoExSostenitori([sede])
+        sostenitori = elenco.risultati()
+        self.assertTrue(sostenitore1 in sostenitori)
+        self.assertTrue(sostenitore2 not in sostenitori)
+        self.assertTrue(socio1 not in sostenitori)
+        self.assertTrue(socio2 not in sostenitori)
+
+        Appartenenza.objects.create(persona=sostenitore1, sede=sede, inizio=poco_fa(), membro=Appartenenza.SOSTENITORE)
+
+        elenco = ElencoExSostenitori([sede])
+        sostenitori = elenco.risultati()
+        self.assertTrue(sostenitore1 not in sostenitori)
+        self.assertTrue(sostenitore2 not in sostenitori)
+        self.assertTrue(socio1 not in sostenitori)
+        self.assertTrue(socio2 not in sostenitori)
+
 
 class TestFunzionaleUfficioSoci(TestFunzionale):
 
@@ -322,8 +373,8 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
 
         locale = crea_sede(presidente=us_locale, genitore=regionale)
 
-        sessione_regionale = self.sessione_utente(persona=us_regionale)
-        sessione_locale = self.sessione_utente(persona=us_locale)
+        sessione_regionale = self.sessione_utente(persona=us_regionale, wait_time=1)
+        sessione_locale = self.sessione_utente(persona=us_locale, wait_time=1)
 
         # Prima di tutto, assicurati che il socio ordinario risulti correttamente
         # nell'elenco del regionale.
@@ -367,6 +418,135 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
             self.presente_in_elenco(sessione_regionale, persona=ordinario),
             msg="L'ex ordinario non è più in elenco al regionale"
         )
+
+    def test_reclama_dipendente(self):
+
+        # Crea oggetti e nomina i delegati US regionali e Locali
+        us_locale = crea_persona()
+
+        oggi = poco_fa()
+        inizio_anno = oggi.replace(month=1, day=1)
+        fine_soci = oggi + datetime.timedelta(days=30)
+
+        Tesseramento.objects.create(
+            stato=Tesseramento.APERTO, inizio=inizio_anno, fine_soci=fine_soci,
+            anno=inizio_anno.year, quota_attivo=8, quota_ordinario=8, quota_benemerito=8,
+            quota_aspirante=8, quota_sostenitore=8
+        )
+
+        dipendente, sede, appartenenza = crea_persona_sede_appartenenza(presidente=us_locale)
+        appartenenza.membro = Appartenenza.DIPENDENTE
+        appartenenza.save()
+
+        sessione_locale = self.sessione_utente(persona=us_locale, wait_time=1)
+
+        # Prima di tutto, assicurati che il socio ordinario risulti correttamente
+        # nell'elenco del regionale.
+
+        # Poi, vai alla procedura di reclamo per il locale e completa.
+        sessione_locale.click_link_by_partial_text("Soci")
+        sessione_locale.click_link_by_partial_text("Reclama Persona")
+        sessione_locale.fill('codice_fiscale', dipendente.codice_fiscale)
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+
+        # Completa dati di inizio appartenenza - data nel passato!
+        sessione_locale.fill('app-inizio', "1/1/1910")
+        sessione_locale.select('app-membro', Appartenenza.VOLONTARIO)
+        sessione_locale.select('quota-registra_quota', ModuloReclamaQuota.NO)
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+
+        self.assertTrue(sessione_locale.is_text_present("1. Appartenenza al Comitato"),
+                        msg="Non e possibile reclamare dipendente nel passato")
+
+        # Compila con la data di oggi.
+        sessione_locale.fill('app-inizio', timezone.now().strftime("%d/%m/%Y"))
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+
+        # Controlla elenco dei volontari.
+        sessione_locale.visit("%s/utente/" % self.live_server_url)
+        sessione_locale.click_link_by_partial_text("Soci")
+        sessione_locale.click_link_by_partial_text("Volontari")
+        self.assertTrue(
+            self.presente_in_elenco(sessione_locale, persona=dipendente),
+            msg="Il dipendente è stato reclamato con successo")
+        sessione_locale.click_link_by_partial_text("Dipendenti")
+        self.assertTrue(
+            self.presente_in_elenco(sessione_locale, persona=dipendente),
+            msg="Il dipendente lo è ancora")
+
+    def test_reclama_sostenitore(self):
+
+        # Crea oggetti e nomina i delegati US regionali e Locali
+        us_locale = crea_persona()
+
+        oggi = poco_fa()
+        inizio_anno = oggi.replace(month=1, day=1)
+        fine_soci = oggi + datetime.timedelta(days=30)
+
+        Tesseramento.objects.create(
+            stato=Tesseramento.APERTO, inizio=inizio_anno, fine_soci=fine_soci,
+            anno=inizio_anno.year, quota_attivo=8, quota_ordinario=8, quota_benemerito=8,
+            quota_aspirante=8, quota_sostenitore=8
+        )
+
+        sostenitore, sede, appartenenza = crea_persona_sede_appartenenza(presidente=us_locale)
+        sostenitore.email_contatto = email_fittizzia()
+        sostenitore.save()
+        appartenenza.membro = Appartenenza.SOSTENITORE
+        appartenenza.save()
+
+        sessione_locale = self.sessione_utente(persona=us_locale, wait_time=1)
+
+        # Prima di tutto, assicurati che il socio ordinario risulti correttamente
+        # nell'elenco del regionale.
+
+        # Poi, vai alla procedura di reclamo per il locale e completa.
+        sessione_locale.click_link_by_partial_text("Soci")
+        sessione_locale.click_link_by_partial_text("Reclama Persona")
+        sessione_locale.fill('codice_fiscale', sostenitore.codice_fiscale)
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+
+        sessione_locale.is_text_present('Questa persona è già registrata come sostenitore')
+
+        sessione_locale.visit('%s/us/dimissioni/sostenitore/%s' % (self.live_server_url, sostenitore.pk))
+        sessione_locale.select('motivo', Dimissione.ALTRO)
+        sessione_locale.fill('info', "trasforma")
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+        sessione_locale.is_text_present('Dimissioni registrate')
+
+        self.assertTrue(len(mail.outbox), 1)
+        self.assertTrue(sostenitore.email_contatto in mail.outbox[0].to)
+        self.assertTrue('Non sei pi&#249; sostenitore di Croce Rossa Italiana' in mail.outbox[0].body)
+        self.assertTrue("Altro" in mail.outbox[0].body)
+        self.assertTrue("trasforma" in mail.outbox[0].body)
+        mail.outbox = []
+
+        sessione_locale.visit('%s/us/reclama/' % (self.live_server_url))
+        sessione_locale.fill('codice_fiscale', sostenitore.codice_fiscale)
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+        sessione_locale.is_text_not_present('Questa persona è già registrata come sostenitore')
+
+        # Compila con la data di oggi.
+        sessione_locale.fill('app-inizio', timezone.now().strftime("%d/%m/%Y"))
+        sessione_locale.select('app-membro', Appartenenza.VOLONTARIO)
+        sessione_locale.select('quota-registra_quota', ModuloReclamaQuota.NO)
+        sessione_locale.find_by_xpath("//button[@type='submit']").first.click()
+
+        # Controlla elenchi.
+        sessione_locale.visit("%s/utente/" % self.live_server_url)
+        sessione_locale.click_link_by_partial_text("Soci")
+        sessione_locale.click_link_by_partial_text("Volontari")
+        self.assertTrue(
+            self.presente_in_elenco(sessione_locale, persona=sostenitore),
+            msg="Il sostenitore è stato reclamato con successo")
+        sessione_locale.click_link_by_partial_text("Sostenitori")
+        self.assertFalse(
+            self.presente_in_elenco(sessione_locale, persona=sostenitore),
+            msg="Il sostenitore non lo è più")
+        sessione_locale.click_link_by_partial_text("Ex Sostenitori")
+        self.assertTrue(
+            self.presente_in_elenco(sessione_locale, persona=sostenitore),
+            msg="Il sostenitore è tra gli ex")
 
     def test_richiedi_tesserino(self, extra_headers={}):
         presidente_locale = crea_persona()

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -252,7 +252,7 @@ def us_dimissioni(request, me, pk):
         dim.richiedente = me
         dim.persona = persona
         dim.sede = dim.persona.sede_riferimento()
-        dim.appartenenza = persona.appartenenze_attuali().first()
+        dim.appartenenza = persona.appartenenze_attuali(membro=Appartenenza.VOLONTARIO).first()
         dim.save()
         dim.applica(modulo.cleaned_data['trasforma_in_sostenitore'])
 
@@ -290,7 +290,7 @@ def us_chiudi_sostenitore(request, me, pk):
         dim.richiedente = me
         dim.persona = persona
         dim.sede = dim.persona.sede_riferimento()
-        dim.appartenenza = persona.appartenenze_attuali().first()
+        dim.appartenenza = persona.appartenenze_attuali(membro=Appartenenza.SOSTENITORE).first()
         dim.save()
         dim.applica()
 

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import random
 from collections import OrderedDict
@@ -6,7 +5,8 @@ from collections import OrderedDict
 from django.core.paginator import Paginator
 from django.db.models import Sum, Q
 from django.shortcuts import redirect, get_object_or_404
-from django.utils import timezone
+from django.utils.safestring import mark_safe
+
 from anagrafica.costanti import REGIONALE
 from anagrafica.forms import ModuloNuovoProvvedimento
 from anagrafica.models import Appartenenza, Persona, Estensione, ProvvedimentoDisciplinare, Sede, Dimissione, Riserva, \
@@ -24,11 +24,11 @@ from posta.utils import imposta_destinatari_e_scrivi_messaggio
 from ufficio_soci.elenchi import ElencoSociAlGiorno, ElencoSostenitori, ElencoVolontari, ElencoOrdinari, \
     ElencoElettoratoAlGiorno, ElencoQuote, ElencoPerTitoli, ElencoDipendenti, ElencoDimessi, ElencoTrasferiti, \
     ElencoVolontariGiovani, ElencoEstesi, ElencoInRiserva, ElencoIVCM, ElencoTesseriniSenzaFototessera, \
-    ElencoTesseriniRichiesti, ElencoTesseriniDaRichiedere
+    ElencoTesseriniRichiesti, ElencoTesseriniDaRichiedere, ElencoExSostenitori
 from ufficio_soci.forms import ModuloCreazioneEstensione, ModuloAggiungiPersona, ModuloReclamaAppartenenza, \
     ModuloReclamaQuota, ModuloReclama, ModuloCreazioneDimissioni, ModuloVerificaTesserino, ModuloElencoRicevute, \
     ModuloCreazioneRiserva, ModuloCreazioneTrasferimento, ModuloQuotaVolontario, ModuloNuovaRicevuta, ModuloFiltraEmissioneTesserini, \
-    ModuloLavoraTesserini, ModuloScaricaTesserini
+    ModuloLavoraTesserini, ModuloScaricaTesserini, ModuloDimissioniSostenitore
 from ufficio_soci.models import Quota, Tesseramento, Tesserino, Riduzione
 
 
@@ -90,14 +90,18 @@ def us_reclama(request, me):
                 if p.reclamabile_in_sede(s):  # Posso reclamare?
                     sedi += [s]  # Aggiungi a elenco sedi
 
+            if p.appartenenze_attuali().filter(membro=Appartenenza.SOSTENITORE).exists():
+                messaggio = "Questa persona è già registrata come sostenitore. " \
+                            r"Prima di poterla reclamare deve essere dimessa dal ruolo di sostenitore"
+            else:
+                messaggio = "Non puoi reclamare questa persona in nessuna delle tue Sedi. Potrebbe " \
+                            "essere già appartenente a qualche Comitato. "
+
             if sedi:
                 return redirect("/us/reclama/%d/" % (p.pk,))
 
             else:
-                modulo.add_error('codice_fiscale', "Non puoi reclamare questa persona "
-                                                   "in nessuna delle tue Sedi. Potrebbe "
-                                                   "essere già appartenente a qualche "
-                                                   "Comitato. ")
+                modulo.add_error('codice_fiscale', mark_safe(messaggio))
 
         except Persona.DoesNotExist:
             modulo.add_error('codice_fiscale', "Nessuna Persona registrata in Gaia "
@@ -121,10 +125,15 @@ def us_reclama_persona(request, me, persona_pk):
         if persona.reclamabile_in_sede(s):  # Posso reclamare?
             sedi += [s]  # Aggiungi a elenco sedi
 
+    if persona.appartenenze_attuali().filter(membro=Appartenenza.SOSTENITORE).exists():
+        messaggio_extra = "<br>Questa persona è già registrata come sostenitore. Prima di poterla reclamare deve essere dimessa dal ruolo di sostenitore"
+    else:
+        messaggio_extra = ""
+
     if not sedi:  # Se non posso reclamarlo in nessuna sede
         return errore_generico(request, me, titolo="Impossibile reclamare appartenenza",
                                messaggio="Questa persona non può essere reclamata in "
-                                         "nessuna delle sedi di tua competenza. ",
+                                         "nessuna delle sedi di tua competenza. " + messaggio_extra,
                                torna_titolo="Torna indietro",
                                torna_url="/us/reclama/")
 
@@ -149,16 +158,30 @@ def us_reclama_persona(request, me, persona_pk):
 
         continua = True
         if not modulo_quota.is_valid() and modulo_quota.get('registra_quota') == modulo_quota.SI:
-                continua = False
+            continua = False
 
-        vecchia_appartenenza = Appartenenza.query_attuale(persona=persona,
-                                                          membro=Appartenenza.ORDINARIO).first()
-        if vecchia_appartenenza:  # Se ordinario presso il regionale.
-            if modulo_appartenenza.cleaned_data['inizio'] < vecchia_appartenenza.inizio:
+        appartenenza_ordinario = Appartenenza.query_attuale(persona=persona, membro=Appartenenza.ORDINARIO).first()
+        if appartenenza_ordinario:  # Se ordinario presso il regionale.
+            if modulo_appartenenza.cleaned_data['inizio'] < appartenenza_ordinario.inizio:
                 modulo_appartenenza.add_error('inizio', "La persona non era socio ordinario CRI alla "
                                                         "data selezionata. Inserisci la data corretta di "
                                                         "cambio appartenenza.")
                 continua = False
+
+        appartenenza_dipendente = Appartenenza.query_attuale(persona=persona, membro=Appartenenza.DIPENDENTE).first()
+        if appartenenza_dipendente:  # Se dipendente.
+            if modulo_appartenenza.cleaned_data['inizio'] < appartenenza_dipendente.inizio:
+                modulo_appartenenza.add_error('inizio', "La persona non era dipendente alla "
+                                                        "data selezionata. Inserisci la data corretta di "
+                                                        "cambio appartenenza.")
+                continua = False
+
+        # Controllo eta' minima socio
+        if modulo_appartenenza.cleaned_data.get('membro') in Appartenenza.MEMBRO_SOCIO \
+                and persona.eta < Persona.ETA_MINIMA_SOCIO:
+            modulo_appartenenza.add_error('membro', "I soci di questo tipo devono avere almeno "
+                                                    "%d anni. " % Persona.ETA_MINIMA_SOCIO)
+            continua = False
 
         # Controllo eta' minima socio
         if modulo_appartenenza.cleaned_data.get('membro') in Appartenenza.MEMBRO_SOCIO \
@@ -173,9 +196,10 @@ def us_reclama_persona(request, me, persona_pk):
             app.persona = persona
             app.save()
 
-            if vecchia_appartenenza:  # Termina app. ordinario
-                vecchia_appartenenza.fine = app.inizio
-                vecchia_appartenenza.save()
+            # Termina app. ordinario - I dipendenti rimangono tali
+            if appartenenza_ordinario:
+                appartenenza_ordinario.fine = app.inizio
+                appartenenza_ordinario.save()
 
             q = modulo_quota.cleaned_data
             riduzione = q.get('riduzione', None)
@@ -212,7 +236,6 @@ def us_reclama_persona(request, me, persona_pk):
     }
 
     return 'us_reclama_persona.html', contesto
-
 
 
 @pagina_privata
@@ -253,6 +276,37 @@ def us_dimissioni(request, me, pk):
     return 'us_dimissioni.html', contesto
 
 
+@pagina_privata
+def us_chiudi_sostenitore(request, me, pk):
+
+    modulo = ModuloDimissioniSostenitore(request.POST or None)
+    persona = get_object_or_404(Persona, pk=pk)
+
+    if not me.permessi_almeno(persona, MODIFICA):
+        return redirect(ERRORE_PERMESSI)
+
+    if modulo.is_valid():
+        dim = modulo.save(commit=False)
+        dim.richiedente = me
+        dim.persona = persona
+        dim.sede = dim.persona.sede_riferimento()
+        dim.appartenenza = persona.appartenenze_attuali().first()
+        dim.save()
+        dim.applica()
+
+        messaggio = "Le dimissioni sono state registrate con successo"
+
+        return messaggio_generico(request, me, titolo="Dimissioni registrate",
+                                  messaggio=messaggio,
+                                  torna_titolo="Vai allo storico appartenenze",
+                                  torna_url=persona.url_profilo_appartenenze)
+
+    contesto = {
+        "modulo": modulo,
+        "persona": persona,
+    }
+
+    return 'us_dimissioni.html', contesto
 
 
 @pagina_privata(permessi=(GESTIONE_SOCI,))
@@ -643,6 +697,7 @@ def us_elenchi(request, me, elenco_tipo):
         "estesi": (ElencoEstesi, "Elenco dei Volontari Estesi/In Estensione"),
         "soci": (ElencoSociAlGiorno, "Elenco dei Soci"),
         "sostenitori": (ElencoSostenitori, "Elenco dei Sostenitori"),
+        "ex-sostenitori": (ElencoExSostenitori, "Elenco degli Ex Sostenitori"),
         "elettorato": (ElencoElettoratoAlGiorno, "Elenco Elettorato", "us_elenco_inc_elettorato.html"),
         "titoli": (ElencoPerTitoli, "Ricerca dei soci per titoli"),
     }


### PR DESCRIPTION
Fix #459 

Work in progress

* [x] Quando un volontario ha più di tipi di appartenenze quella come volontario vince, negli elenchi e nelle visualizzazioni
* [x] Avvisare quando si reclama un sostenitore di chiudere l'appartenenza come sostenitore
* [x] Si può reclamare come volontario un dipendente mantenendo la doppia appartenenza (da conversazione telefonica con @galamarco )
* [x] Permettere a US dimissioni di sostenitori con un processo analogo a volontari, e con notifica, ma senza selezione dei motivi e -ovviamente- senza selezione di trasformarlo in sostenitore
* [x] Aggiungere elenco ex-sostenitori
* [x] Gli elenchi non sono modificati per filtrare sostenitori diventati volontari