### PR TITLE
usa mptt da git con fix per raw_id_fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Markdown==2.6
 django-bootstrap3==7.0.0
 django-filter==0.9.2
 django-autoslug==1.9.3
-django-mptt==0.8.6
+https://github.com/django-mptt/django-mptt/archive/10783b81c24704782f488c951298bc92d0288501.zip
 phonenumbers==7.0.2
 Pillow==3.2.0
 django-countries==3.3


### PR DESCRIPTION
Fix #522 

E' stato incorporato il nostro fix nel progetto upstream
In attesa della release ne ho fatto un mirror e si installa da lì in attesa di una release ufficiale