### PR TITLE
Fix #336, informativa su browser supportati

### DIFF
--- a/base/templates/base_browser_supportati.html
+++ b/base/templates/base_browser_supportati.html
@@ -1,0 +1,32 @@
+{% extends "base_vuota.html" %}
+
+{% load bootstrap3 %}
+
+{% block pagina_titolo %}Browser supportati su Gaia{% endblock %}
+
+{% block pagina_principale %}
+
+    <div class="container">
+        <div class="col-md-12">
+            <h2><i class="fa fa-shield"></i> Elenco browser</h2>
+            <hr />
+            <p>
+                Gli sviluppatori di Gaia si impegnano per garantire la massima compatibilità con tutti i browser e
+                dispositivi, tuttavia possono effettuare i test solo su un numero limitato di piattaforme.<br>
+                Pertanto ti consigliamo, per usufruire al meglio di Gaia, di usare uno dei browser sotto elencati.<br>
+            </p>
+            <p>
+                <ul>
+                  <li>Internet Explorer 11</li>
+                  <li>Edge</li>
+                  <li>Chrome 50+</li>
+                  <li>Firefox 45+</li>
+                  <li>Safari 6+</li>
+                  <li>Android 4.0</li>
+                  <li>iOS 8.0</li>
+                </ul>
+            </p>
+        </div>
+    </div>
+
+{% endblock %}

--- a/base/templates/base_informazioni.html
+++ b/base/templates/base_informazioni.html
@@ -113,6 +113,9 @@
 
             <p>Leggi l'informativa sul trattamento dei dati e scopri le <a href="/informazioni/condizioni/">condizioni d'uso</a> di Gaia e le <a href="{% url 'informazioni_cookie' %}">politiche di uso dei cookie</a>.</p>
 
+            <h2><i class="fa fa-shield"></i> Browser supportati</h2>
+
+            <p>Controlla che il tuo browser sia correttamente supportato <a href="{% url 'browser_supportati' %}">qua</a>.</p>
 
             </div>
         </div>

--- a/base/viste.py
+++ b/base/viste.py
@@ -60,6 +60,14 @@ def index(request, me):
     return 'base_home.html', contesto
 
 @pagina_pubblica
+def browser_supportati(request, me):
+    """
+    Mostra semplicemente l'elenco dei browser supportati
+    """
+    return 'base_browser_supportati.html'
+
+
+@pagina_pubblica
 def manutenzione(request, me):
     """
     Mostra semplicemente la pagina di manutenzione ed esce.

--- a/jorvik/urls.py
+++ b/jorvik/urls.py
@@ -73,6 +73,7 @@ urlpatterns = [
     url(r'^informazioni/sedi/$', base.viste.informazioni_sedi),
     url(r'^informazioni/sedi/(?P<slug>.*)/$', base.viste.informazioni_sede),
     url(r'^informazioni/formazione/$', base.viste.formazione),
+    url(r'^informazioni/browser-supportati/$', base.viste.browser_supportati, name='browser_supportati'),
 
     # Applicazioni
     url(r'^utente/$', anagrafica.viste.utente),


### PR DESCRIPTION
Fix #336 

@PaoloGiustiniani puoi vedere la pagina qui http://luke.staging.sviluppo-gaia.ovh/informazioni/browser-supportati/
Sul testo introduttivo ci sono indicazioni aggiuntive?