### PR TITLE
Avvertimento per versioni di sviluppo o staging di Gaia

### DIFF
--- a/autenticazione/funzioni.py
+++ b/autenticazione/funzioni.py
@@ -49,7 +49,7 @@ def pagina_pubblica(funzione=None, permetti_embed=False):
 
         contesto.update({"me": request.me})
         contesto.update({"embed": embed})
-        contesto.update({"debug": DEBUG})
+        contesto.update({"debug": DEBUG and request.META['SERVER_NAME'] != "testserver"})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -77,7 +77,7 @@ def pagina_anonima(funzione, pagina='/utente/'):
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": None})
-        contesto.update({"debug": DEBUG})
+        contesto.update({"debug": DEBUG and request.META['SERVER_NAME'] != "testserver"})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -122,7 +122,7 @@ def pagina_privata(funzione=None, pagina=LOGIN_URL, permessi=[]):
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": request.me})
-        contesto.update({"debug": DEBUG})
+        contesto.update({"debug": DEBUG and request.META['SERVER_NAME'] != "testserver"})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -166,7 +166,7 @@ def pagina_privata_no_cambio_firma(funzione=None, pagina=LOGIN_URL, permessi=[])
 
         extra = {}
         extra.update({"me": request.me})
-        extra.update({"debug": DEBUG})
+        extra.update({"debug": DEBUG and request.META['SERVER_NAME'] != "testserver"})
         extra.update({"request": request})
         extra.update({"menu": menu(request)})
 
@@ -176,7 +176,7 @@ def pagina_privata_no_cambio_firma(funzione=None, pagina=LOGIN_URL, permessi=[])
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": request.me})
-        contesto.update({"debug": DEBUG})
+        contesto.update({"debug": DEBUG and request.META['SERVER_NAME'] != "testserver"})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -211,7 +211,7 @@ class VistaDecorata(object):
         except AttributeError:
             pass
         contesto.update({'embed': embed})
-        contesto.update({'debug': DEBUG})
+        contesto.update({"debug": DEBUG and self.request.META['SERVER_NAME'] != "testserver"})
         return contesto
 
     def get_context_data(self, **kwargs):

--- a/autenticazione/funzioni.py
+++ b/autenticazione/funzioni.py
@@ -6,7 +6,7 @@ from django.utils.http import urlencode
 import functools
 from anagrafica.permessi.costanti import ERRORE_ORFANO, ERRORE_PERMESSI
 from base.menu import menu
-from jorvik.settings import LOGIN_URL
+from jorvik.settings import LOGIN_URL, DEBUG
 
 __author__ = 'alfioemanuele'
 
@@ -49,6 +49,7 @@ def pagina_pubblica(funzione=None, permetti_embed=False):
 
         contesto.update({"me": request.me})
         contesto.update({"embed": embed})
+        contesto.update({"debug": DEBUG})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -76,6 +77,7 @@ def pagina_anonima(funzione, pagina='/utente/'):
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": None})
+        contesto.update({"debug": DEBUG})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -120,6 +122,7 @@ def pagina_privata(funzione=None, pagina=LOGIN_URL, permessi=[]):
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": request.me})
+        contesto.update({"debug": DEBUG})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -163,6 +166,7 @@ def pagina_privata_no_cambio_firma(funzione=None, pagina=LOGIN_URL, permessi=[])
 
         extra = {}
         extra.update({"me": request.me})
+        extra.update({"debug": DEBUG})
         extra.update({"request": request})
         extra.update({"menu": menu(request)})
 
@@ -172,6 +176,7 @@ def pagina_privata_no_cambio_firma(funzione=None, pagina=LOGIN_URL, permessi=[])
             return richiesta  # Passa attraverso.
 
         contesto.update({"me": request.me})
+        contesto.update({"debug": DEBUG})
         contesto.update({"request": request})
         contesto.update({"menu": menu(request)})
         return render_to_response(template, RequestContext(request, contesto))
@@ -206,6 +211,7 @@ class VistaDecorata(object):
         except AttributeError:
             pass
         contesto.update({'embed': embed})
+        contesto.update({'debug': DEBUG})
         return contesto
 
     def get_context_data(self, **kwargs):

--- a/base/templates/base_vuota.html
+++ b/base/templates/base_vuota.html
@@ -66,9 +66,15 @@
                 </div><!--/.navbar-collapse -->
               </div>
             </nav>
+
+            {% if debug %}
+                {% include "includes/debug.html" %}
+            {% endif %}
+
             {% for message in messages %}
                 <div class="text-center alert {{ message|level_to_bootstrap }}" role="alert">{{ message }}</div>
             {% endfor %}
+
 
         {% endif %}
         

--- a/base/templates/includes/debug.html
+++ b/base/templates/includes/debug.html
@@ -40,34 +40,35 @@
             <p>Non stai usando il sito web ufficiale del Progetto Gaia. Questa &egrave; una versione di prova,
                 nota anche come versione di <i>staging</i> o di <i>sviluppo</i>.</p>
             <p>Queste versioni di Gaia sono utilizzate per il training del personale di supporto, per le
-                giornate di formazione sulla piattaforma, nelle dimostrazioni, oppure dagli sviluppatori
+                giornate di formazione sulla piattaforma, durante le dimostrazioni, oppure dagli sviluppatori
                 per assicurarsi che le nuove funzionalit&agrave; siano pronte per il rilascio al pubblico.</p>
             <p>Se non sai cosa &egrave; una versione di prova, e sei finito/a qui per sbaglio, niente paura.
-                Usa il pulsante sotto per accedere alla versione ufficiale di Gaia, quella che &egrave;
+                Usa il pulsante sotto per accedere alla versione ufficiale di Gaia, quella che &egrave; normalmente
                 accessibile all'indirizzo <strong>gaia.cri.it</strong>.</p>
             <p>&nbsp;</p>
 
-            <h4>Che differenze ci sono?</h4>
+            <h4>Che differenze ci sono con la versione ufficiale?</h4>
             <p>Le versioni di prova di Gaia sono generalmente molto simili alla versione ufficiale, ma
                 con delle piccole differenze. Ad esempio, possono contenere delle nuove funzionalit&agrave;
-                che devono essere messe alla prova prima di essere rilasciate al pubblico.</p>
-            <p>In genere, possono esserci delle discordanze tra i dati in questa versione e quelli sulla versione
-                ufficiale di Gaia. In quel caso, fai affidamento sulla versione ufficiale. Non &egrave; detto
+                che devono essere testate prima di essere rilasciate al pubblico.</p>
+            <p>In genere possono esserci delle discordanze tra i dati in questa versione e quelli sulla versione
+                ufficiale di Gaia. In questo caso, fai riferimento alla versione ufficiale. Inoltre non &egrave; detto
                 che le funzionalit&agrave; in questa versione di prova verranno integrate in Gaia.</p>
             <p>&nbsp;</p>
 
-            <h4>Che succede se premo questo pulsante?</h4>
-            <p>Niente timore, premi quel pulsante e scoprilo. </p>
-            <p>Per quanto questa versione simuler&agrave; le stesse procedure di Gaia, e troverai dei messaggi nella
-                tua casella di posta in uscita su questa versione di Gaia, le procedure non saranno iniziate veramente
-                e questa versione di Gaia non inoltra davvero i messaggi di posta agli altri utenti.</p>
-            <p>Sentiti libero di effettuare tenativi. Ricorda per&ograve; di rispettare sempre i termini e le condizioni
+            <h4>Che cosa succede se premo questo pulsante?</h4>
+            <p>Niente paura, premi il pulsante e scoprilo! </p>
+            <p>Per quanto questa versione simuli le stesse procedure di Gaia, queste non saranno eseguite veramente.</p>
+            <p>Nella casella di posta del tuo utente troverai i messaggi che vengono generati all'esecuzione
+              delle varie procedure, nonostatene ci&ograve; questa versione di Gaia non inoltra davvero i messaggi
+              verso le caselle di posta agli altri utenti.</p>
+            <p>Sentiti libero di effettuare prove. Ricorda per&ograve; di rispettare sempre i termini e le condizioni
                 del servizio, e la privacy degli altri.</p>
             <p>&nbsp;</p>
 
-            <h4>Altri quesiti?</h4>
-            <p>Se hai domande su questa versione di Gaia, vuoi utilizzare una versione di prova di Gaia per della
-                formazione nel tuo Comitato, se vuoi segnalare un malfunzionamento, o per qualunque altra domanda,
+            <h4>Ci sono altri quesiti?</h4>
+            <p>Se hai domande su questa versione di Gaia, se vuoi utilizzare una versione di prova di Gaia per fare
+                formazione nel tuo Comitato, se vuoi segnalare un malfunzionamento, o per qualunque altra richiesta
                 scrivici a:</p>
             <p>
                 <a href="mailto:info@gaia.cri.it">

--- a/base/templates/includes/debug.html
+++ b/base/templates/includes/debug.html
@@ -1,0 +1,91 @@
+<nav class="navbar navbar-inverse navbar-fixed-bottom">
+  <div class="container">
+    <div class="navbar-header">
+      <a class="navbar-brand">
+          <i class="fa fa-bug"></i>
+          <span class="text-danger">Ehi, tu!</span>
+          Stai usando una versione di prova di Gaia.
+      </a>
+    </div>
+    <div id="navbar" class="navbar-collapse collapse allinea-destra">
+            <p class="navbar-btn btn-group">
+                <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#avviso-staging">
+                    <i class="fa fa-question-circle"></i>
+                    Cosa vuol dire?
+                </a>
+
+                <a class="btn btn-sm btn-primary" href="https://gaia.cri.it">
+                    <i class="fa fa-sign-out"></i>
+                    Vai a gaia.cri.it (produzione)
+                </a>
+            </p>
+    </div><!--/.navbar-collapse -->
+  </div>
+</nav>
+
+<!-- Modal -->
+<div class="modal fade" id="avviso-staging" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">
+            <i class="fa fa-bug"></i>
+            Versione di prova di Gaia
+        </h4>
+      </div>
+      <div class="modal-body">
+
+            <h4>Cosa vuol dire versione di prova?</h4>
+            <p>Non stai usando il sito web ufficiale del Progetto Gaia. Questa &egrave; una versione di prova,
+                nota anche come versione di <i>staging</i> o di <i>sviluppo</i>.</p>
+            <p>Queste versioni di Gaia sono utilizzate per il training del personale di supporto, per le
+                giornate di formazione sulla piattaforma, nelle dimostrazioni, oppure dagli sviluppatori
+                per assicurarsi che le nuove funzionalit&agrave; siano pronte per il rilascio al pubblico.</p>
+            <p>Se non sai cosa &egrave; una versione di prova, e sei finito/a qui per sbaglio, niente paura.
+                Usa il pulsante sotto per accedere alla versione ufficiale di Gaia, quella che &egrave;
+                accessibile all'indirizzo <strong>gaia.cri.it</strong>.</p>
+            <p>&nbsp;</p>
+
+            <h4>Che differenze ci sono?</h4>
+            <p>Le versioni di prova di Gaia sono generalmente molto simili alla versione ufficiale, ma
+                con delle piccole differenze. Ad esempio, possono contenere delle nuove funzionalit&agrave;
+                che devono essere messe alla prova prima di essere rilasciate al pubblico.</p>
+            <p>In genere, possono esserci delle discordanze tra i dati in questa versione e quelli sulla versione
+                ufficiale di Gaia. In quel caso, fai affidamento sulla versione ufficiale. Non &egrave; detto
+                che le funzionalit&agrave; in questa versione di prova verranno integrate in Gaia.</p>
+            <p>&nbsp;</p>
+
+            <h4>Che succede se premo questo pulsante?</h4>
+            <p>Niente timore, premi quel pulsante e scoprilo. </p>
+            <p>Per quanto questa versione simuler&agrave; le stesse procedure di Gaia, e troverai dei messaggi nella
+                tua casella di posta in uscita su questa versione di Gaia, le procedure non saranno iniziate veramente
+                e questa versione di Gaia non inoltra davvero i messaggi di posta agli altri utenti.</p>
+            <p>Sentiti libero di effettuare tenativi. Ricorda per&ograve; di rispettare sempre i termini e le condizioni
+                del servizio, e la privacy degli altri.</p>
+            <p>&nbsp;</p>
+
+            <h4>Altri quesiti?</h4>
+            <p>Se hai domande su questa versione di Gaia, vuoi utilizzare una versione di prova di Gaia per della
+                formazione nel tuo Comitato, se vuoi segnalare un malfunzionamento, o per qualunque altra domanda,
+                scrivici a:</p>
+            <p>
+                <a href="mailto:info@gaia.cri.it">
+                    <i class="fa fa-envelope"></i>
+                    info@gaia.cri.it
+                </a>
+            </p>
+
+
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+            Chiudi questo messaggio
+        </button>
+        <a class="btn btn-primary" href="https://gaia.cri.it">
+            Vai alla versione ufficiale di Gaia (gaia.cri.it)
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Questa PR aggiunge un banner presente in tutte le pagine di Gaia quando si sta utilizzando una versione di sviluppo o di staging di Gaia. 

### Obiettivi
- Rendere facilmente riconoscibile le versioni di staging da quelle ufficiali, per chi usa frequentemente entrambe le versioni (prego @matthewmazzoleni)
- Tranquillizzare le pecorelle smarrite che si trovano qui per sbaglio (anche se molto difficile, considerando il robots.txt)

### Screenshot
![image](https://cloud.githubusercontent.com/assets/621062/26019217/b056064e-376b-11e7-9dc7-8c63bec5979a.png)

![image](https://cloud.githubusercontent.com/assets/621062/26019221/b77ffd44-376b-11e7-9cb7-60866687b693.png)
