### PR TITLE
Fix filtro autocompletamento su flag Sede.attiva

### DIFF
--- a/anagrafica/admin.py
+++ b/anagrafica/admin.py
@@ -78,8 +78,8 @@ class AdminSede(ReadonlyAdminMixin, MPTTModelAdmin):
     list_display_links = ('nome', 'estensione',)
     inlines = [InlineDelegaSede,]
 
-# admin.site.register(Appartenenza)
 
+# admin.site.register(Appartenenza)
 @admin.register(Appartenenza)
 class AdminAppartenenza(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["membro", "persona__nome", "persona__cognome", "persona__codice_fiscale",

--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -148,7 +148,7 @@ class SedeAutocompletamento(AutocompletamentoBase):
         return super(SedeAutocompletamento, self).choices_for_request()
 
 
-class ComitatoAutocompletamento(AutocompletamentoBase):
+class ComitatoAutocompletamento(SedeAutocompletamento):
     search_fields = ['nome', 'genitore__nome', ]
     model = Sede
 
@@ -160,7 +160,7 @@ class ComitatoAutocompletamento(AutocompletamentoBase):
         return super(ComitatoAutocompletamento, self).choices_for_request()
 
 
-class SedeTrasferimentoAutocompletamento(AutocompletamentoBase):
+class SedeTrasferimentoAutocompletamento(SedeAutocompletamento):
     search_fields = ['nome', 'genitore__nome', ]
     model = Sede
 


### PR DESCRIPTION
Il flag attiva non viene usato in alcune situazioni:

* Autocompletamenti
* Gestione del flag dei figli del comitato disattivato

Comportamenti implementati in questa PR

* [x] Filtro su flag attiva negli autocompletamenti
* [x] Gestione del flag sui figli (forzandolo a false in caso sia impostato sul genitore?)

Fix #612 