### PR TITLE
JO-379: Bonifica richieste tesserini Roma Capitale/Lazio

### DIFF
--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -172,6 +172,18 @@ class SedeTrasferimentoAutocompletamento(SedeAutocompletamento):
         return super(SedeTrasferimentoAutocompletamento, self).choices_for_request()
 
 
+class SedeRegionaleAutocompletamento(SedeAutocompletamento):
+    search_fields = ['nome']
+    model = Sede
+
+    def choices_for_request(self):
+        self.choices = self.choices.filter(
+            tipo=Sede.COMITATO,
+            estensione__in=[REGIONALE],
+        )
+        return super(SedeRegionaleAutocompletamento, self).choices_for_request()
+
+
 class SedeNuovoCorsoAutocompletamento(SedeAutocompletamento):
     def choices_for_request(self):
         return self.persona.oggetti_permesso(GESTIONE_CORSI_SEDE)
@@ -183,6 +195,7 @@ autocomplete_light.register(SostenitoreAutocompletamento)
 autocomplete_light.register(VolontarioSedeAutocompletamento)
 autocomplete_light.register(IscrivibiliCorsiAutocompletamento)
 autocomplete_light.register(SedeAutocompletamento)
+autocomplete_light.register(SedeRegionaleAutocompletamento)
 autocomplete_light.register(ComitatoAutocompletamento)
 autocomplete_light.register(SedeTrasferimentoAutocompletamento)
 autocomplete_light.register(SedeNuovoCorsoAutocompletamento)

--- a/anagrafica/forms.py
+++ b/anagrafica/forms.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
 from django.forms import ModelForm
 from django.utils.safestring import mark_safe
+from django.templatetags.static import static
 from django.utils.timezone import now
 
 from anagrafica.models import Sede, Persona, Appartenenza, Documento, Estensione, ProvvedimentoDisciplinare, Delega, \
@@ -494,3 +495,21 @@ class ModuloUSModificaUtenza(ModuloUtenza):
             raise ValidationError("Puoi solo cambiare l'e-mail di accesso se questa è stata "
                                   "richiesta dall'utente, oppure hai già avvisato l'utente della "
                                   "modifica e della nuova e-mail per accedere.")
+
+
+class ModuloSpostaTesserini(forms.Form):
+
+    destinazione = autocomplete_light.ModelChoiceField("SedeRegionaleAutocompletamento", error_messages={
+        'invalid': "E' possibile trasferire i tesserini esclusivamente verso un Comitato Regionale"
+    })
+
+    @property
+    def media(self):
+        extra = '' if settings.DEBUG else '.min'
+        js = [
+            'core.js',
+            'vendor/jquery/jquery%s.js' % extra,
+            'jquery.init.js',
+            'admin/RelatedObjectLookups.js',
+        ]
+        return forms.Media(js=[static('admin/js/%s' % url) for url in js]) + super(ModuloSpostaTesserini, self).media

--- a/anagrafica/templates/admin/anagrafica/trasferimento_tesserini.html
+++ b/anagrafica/templates/admin/anagrafica/trasferimento_tesserini.html
@@ -1,0 +1,50 @@
+{% extends "admin/base_custom.html" %}
+{% load i18n admin_urls l10n %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+    {% if eseguito %}
+    <p>
+        I tesserini dei seguenti comitati sono stati trasferiti alla sede {{ destinazione }}
+        <ul>
+        {% for sede in queryset %}
+            <li>{{ sede }}</li>
+        {% endfor %}
+        </ul>
+    </p>
+    {% else %}
+    <p>
+        Stai per trasferire le richieste di emissione di tesserini per i seguenti comitati:
+        <ul>
+        {% for sede in queryset %}
+            <li>{{ sede }}</li>
+        {% endfor %}
+        </ul>
+    </p>
+    <p>
+        Questa modifica viene effettuata senza annullare le richieste esistenti, ma cambiando la sede di appartenenza delle richieste stess.
+    </p>
+    {% endif %}
+    {% if not eseguito %}
+    <form action="{% url "admin:anagrafica_sposta_tesserini_post" %}" method="post" {% if form.is_multipart %}enctype="multipart/form-data"{% endif %}>
+    {{ form.errors }}
+        {% csrf_token %}
+        <input type="hidden" name="action" value="{{ action }}">
+        <input type="hidden" name="do_action" value="yes">
+        {{ form.as_p }}
+        <div>
+            <input type="submit" class="default" style="float: none" value="{{ etichetta_invio }}">
+        </div>
+        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ pks|join:',' }}" />
+    </form>
+    {% endif %}
+{% endblock %}

--- a/anagrafica/tests.py
+++ b/anagrafica/tests.py
@@ -1,9 +1,11 @@
 import datetime
 import re
+from collections import defaultdict
 from io import BytesIO
 from random import randint, choice
 
 import unicodecsv
+from django.contrib.admin import helpers
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import Client
@@ -36,6 +38,7 @@ from base.utils_tests import crea_persona_sede_appartenenza, crea_persona, crea_
 from formazione.models import Aspirante, CorsoBase, PartecipazioneCorsoBase
 from posta.models import Messaggio, Autorizzazione
 from ufficio_soci.forms import ModuloElencoVolontari
+from ufficio_soci.models import Tesserino
 from veicoli.models import Autoparco
 
 
@@ -2459,6 +2462,64 @@ class TestAnagrafica(TestCase):
 
 
 class TestFunzionaliAnagrafica(TestFunzionale):
+
+    def _crea_dati_tesserini(self, presidente, sede):
+        tesserini = defaultdict(list)
+        persone = []
+        for x in range(0, 10):
+            persona = crea_persona()
+            persone.append(persona)
+            crea_appartenenza(persona, sede)
+            richiesta = choice(
+                (Tesserino.RIFIUTATO, Tesserino.RICHIESTO, Tesserino.ACCETTATO)
+            )
+            tesserini[richiesta].append(
+                Tesserino.objects.create(persona=persona, emesso_da=sede, tipo_richiesta=choice(
+                    (Tesserino.RILASCIO, Tesserino.DUPLICATO, Tesserino.RINNOVO)
+                ), stato_richiesta=richiesta, motivo_richiesta='test', richiesto_da=presidente)
+            )
+        return tesserini, persone
+
+    def test_spostamento_tesserini(self):
+        presidente1 = crea_persona()
+        sede1 = crea_sede(presidente=presidente1, estensione=REGIONALE)
+        crea_utenza(presidente1, email=email_fittizzia())
+        tesserini1, persone1 = self._crea_dati_tesserini(presidente1, sede1)
+
+        presidente2 = crea_persona()
+        sede2 = crea_sede(presidente=presidente2, estensione=REGIONALE)
+        crea_utenza(presidente2, email=email_fittizzia())
+        tesserini2, persone2 = self._crea_dati_tesserini(presidente2, sede2)
+
+        admin = crea_utenza(None, email=email_fittizzia())
+        admin.is_staff = True
+        admin.is_superuser = True
+        admin.save()
+
+        for stato, tesserini in tesserini1.items():
+            self.assertEqual(sede1.tesserini_emessi.filter(stato_richiesta=stato).count(), len(tesserini))
+        for stato, tesserini in tesserini2.items():
+            self.assertEqual(sede2.tesserini_emessi.filter(stato_richiesta=stato).count(), len(tesserini))
+        data = {
+            helpers.ACTION_CHECKBOX_NAME: [sede1.pk],
+            'destinazione': [sede2],
+            'do_action': True,
+        }
+        self.client.login(username=admin.email, password='prova')
+        response = self.client.post(reverse('admin:anagrafica_sposta_tesserini_post'), data=data)
+        self.assertContains(response, '{} tesserini trasferiti con successo'.format(len(tesserini1[Tesserino.RICHIESTO])))
+        sede1.refresh_from_db()
+        sede2.refresh_from_db()
+        for stato, tesserini in tesserini1.items():
+            if stato != Tesserino.RICHIESTO:
+                self.assertEqual(sede1.tesserini_emessi.filter(stato_richiesta=stato).count(), len(tesserini))
+            else:
+                self.assertEqual(sede1.tesserini_emessi.filter(stato_richiesta=stato).count(), 0)
+        for stato, tesserini in tesserini2.items():
+            if stato != Tesserino.RICHIESTO:
+                self.assertEqual(sede2.tesserini_emessi.filter(stato_richiesta=stato).count(), len(tesserini))
+            else:
+                self.assertEqual(sede2.tesserini_emessi.filter(stato_richiesta=stato).count(), len(tesserini) + len(tesserini1[Tesserino.RICHIESTO]))
 
     def test_sede_trasferimento(self):
         presidente = crea_persona()

--- a/ufficio_soci/admin.py
+++ b/ufficio_soci/admin.py
@@ -1,6 +1,13 @@
-from django.contrib import admin
-from ufficio_soci.models import Tesserino, Quota, Tesseramento, Riduzione
+from django.conf.urls import url
+from django.contrib import admin, messages
+from django.contrib.admin import helpers
+from django.contrib.auth import get_permission_codename
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+
 from gruppi.readonly_admin import ReadonlyAdminMixin
+from ufficio_soci.models import Tesserino, Quota, Tesseramento, Riduzione
 
 __author__ = 'alfioemanuele'
 

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -3,16 +3,14 @@ import datetime
 from autocomplete_light import shortcuts as autocomplete_light
 from django import forms
 from django.core.exceptions import ValidationError
-from django.core.validators import MaxValueValidator
 from django.forms import ModelForm
 from django.utils.timezone import now
 
 from anagrafica.forms import ModuloStepAnagrafica
 from anagrafica.models import Estensione, Appartenenza, Persona, Dimissione, Riserva, Trasferimento
-from anagrafica.validators import valida_almeno_14_anni
 from base.utils import rimuovi_scelte, testo_euro
-from ufficio_soci.validators import valida_data_non_nel_futuro
 from ufficio_soci.models import Tesseramento, Quota, Tesserino, Riduzione
+from ufficio_soci.validators import valida_data_non_nel_futuro
 
 
 class ModuloCreazioneEstensione(autocomplete_light.ModelForm):

--- a/ufficio_soci/models.py
+++ b/ufficio_soci/models.py
@@ -25,6 +25,7 @@ class Tesserino(ModelloSemplice, ConMarcaTemporale, ConPDF):
         verbose_name_plural = "Richieste Tesserino Associativo"
         permissions = (
             ("view_tesserino", "Can view tesserino"),
+            ('transfer_tesserino', "Can transfer tesserino"),
         )
 
     persona = models.ForeignKey('anagrafica.Persona', related_name='tesserini', on_delete=models.CASCADE)


### PR DESCRIPTION
Fix #379 

Implementa #379 tramite un'azione ``sposta_tesserini`` per cui selezionando alcune sedi nell'admin relativo, permette di spostare i tesserini dalle sedi selezionate alla sede che viene richiesta nel form visualizzato nella paginata successiva.
Il trasferimento viene implementato modificando la sede di riferimento per tutti i tesserini in stato ``RICHIESTO`` (https://github.com/CroceRossaItaliana/jorvik/pull/649/files#diff-92d47db136c16294acde667432bcb9f0R297)