### PR TITLE
JO-664: Genera semplice report per la Federazione

### DIFF
--- a/anagrafica/forms.py
+++ b/anagrafica/forms.py
@@ -16,7 +16,7 @@ from django.utils.timezone import now
 
 from anagrafica.models import Sede, Persona, Appartenenza, Documento, Estensione, ProvvedimentoDisciplinare, Delega, \
     Fototessera, Trasferimento, Riserva
-from anagrafica.validators import valida_almeno_14_anni
+from anagrafica.validators import valida_almeno_14_anni, valida_data_nel_passato
 from autenticazione.models import Utenza
 from autocomplete_light import shortcuts as autocomplete_light
 
@@ -465,6 +465,11 @@ class ModuloModificaDataInizioAppartenenza(ModelForm):
         if self.instance and not self.instance.modificabile(inizio):
             raise ValidationError("La data non può sovrapporsi con appartenenze precedenti.")
         return inizio
+
+
+class ModuloReportFederazione(forms.Form):
+    data = forms.DateTimeField(help_text="Data e ora per i quali computare il report.",
+                               validators=[valida_data_nel_passato,],)
 
 
 class ModuloImportPresidenti(forms.Form):

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -56,7 +56,7 @@ from base.models import ModelloSemplice, ModelloAlbero, ConAutorizzazioni, ConAl
 from base.stringhe import normalizza_nome, GeneratoreNomeFile
 from base.tratti import ConMarcaTemporale, ConStorico, ConProtocollo, ConDelegati, ConPDF
 from base.utils import is_list, sede_slugify, UpperCaseCharField, TitleCharField, poco_fa, mezzanotte_24_ieri, \
-    mezzanotte_00, mezzanotte_24
+    mezzanotte_00, mezzanotte_24, concept
 from autoslug import AutoSlugField
 
 from curriculum.models import Titolo, TitoloPersonale
@@ -428,6 +428,20 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
             return 0
         al_giorno = al_giorno or date.today()
         return al_giorno.year - self.data_nascita.year - ((al_giorno.month, al_giorno.day) < (self.data_nascita.month, self.data_nascita.day))
+
+    @classmethod
+    @concept
+    def query_eta_minima(cls, eta, al_giorno=None):
+        al_giorno = al_giorno or date.today()
+        data_nascita_massima = al_giorno.replace(year=al_giorno.year - eta)
+        return Q(data_nascita__lte=data_nascita_massima)
+
+    @classmethod
+    @concept
+    def query_eta_massima(cls, eta, al_giorno=None):
+        al_giorno = al_giorno or date.today()
+        data_nascita_minima = al_giorno.replace(year=al_giorno.year - eta)
+        return Q(data_nascita__gte=data_nascita_minima)
 
     @property
     def giovane(self, **kwargs):

--- a/anagrafica/templates/admin_report_federazione.html
+++ b/anagrafica/templates/admin_report_federazione.html
@@ -1,0 +1,69 @@
+{% extends 'base_vuota.html' %}
+
+{% load bootstrap3 %}
+
+{% block pagina_titolo %}
+    Statistiche Gaia CRI {{ ora }}
+{% endblock %}
+
+
+{% block pagina_principale %}
+
+    <p>&nbsp;</p>
+
+    <div class="container">
+
+        <div class="row">
+            <div class="col-md-4">
+                <h3>
+                    Report per la Federazione Internazionale
+                </h3>
+            </div>
+
+            <div class="col-md-8">
+
+                <div class="panel panel-primary">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            Parametri
+                        </h4>
+                    </div>
+                    <div class="panel-body">
+                        <form method="POST">
+                            {% csrf_token %}
+                            {% bootstrap_form modulo %}
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa fa-fw fa-cogs"></i>
+                                Genera report
+                            </button>
+                        </form>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+
+        <code id="report">
+
+            {% if volontari %}
+                Numero totale di soci: {{ volontari }}<br /><br />
+            {% endif %}
+
+            {% if volontari_per_fasce_di_eta %}
+                Soci per fasce di et&agrave;<br />
+                {% for fascia, r in volontari_per_fasce_di_eta %}
+                  - {{ fascia.0 }} <= et&agrave; < {{ fascia.1 }}: {{ r }}<br />
+                {% endfor %}
+                <br />
+            {% endif %}
+
+            {% if decessi %}
+                Dimissioni per decesso registrate nei 365 giorni antecedenti la data:
+                {{ decessi }}
+            {% endif %}
+
+        </code>
+
+    </div>
+{% endblock %}

--- a/anagrafica/validators.py
+++ b/anagrafica/validators.py
@@ -104,9 +104,9 @@ def valida_email_personale(email):
 def valida_data_nel_passato(data):
     if isinstance(data, datetime):
         if data > datetime.now():
-            raise ValidationError("Data ed ora non possono essere nel passato.")
+            raise ValidationError("Data ed ora non possono essere nel futuro.")
     elif isinstance(data, date):
         if data > date.today():
-            raise ValidationError("La data non può essere nel passato.")
+            raise ValidationError("La data non può essere nel futuro.")
     else:
         raise TypeError("Fornito tipo di data non valido.")

--- a/anagrafica/validators.py
+++ b/anagrafica/validators.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 
 import stdnum
 from django.utils import timezone
@@ -99,3 +99,14 @@ def valida_email_personale(email):
         if email and email.lower().startswith(coppia[0]) and email.lower().endswith(coppia[1]):
             raise ValidationError("Non è possibile utilizzare una casella istituzionale come "
                                   "indirizzo e-mail personale.")
+
+
+def valida_data_nel_passato(data):
+    if isinstance(data, datetime):
+        if data > datetime.now():
+            raise ValidationError("Data ed ora non possono essere nel passato.")
+    elif isinstance(data, date):
+        if data > date.today():
+            raise ValidationError("La data non può essere nel passato.")
+    else:
+        raise TypeError("Fornito tipo di data non valido.")

--- a/base/tratti.py
+++ b/base/tratti.py
@@ -148,7 +148,6 @@ class ConStorico(models.Model):
 
         return risultato
 
-
     @classmethod
     @concept
     def query_attuale_in_anno(cls, anno, **kwargs):

--- a/jorvik/urls.py
+++ b/jorvik/urls.py
@@ -316,6 +316,7 @@ urlpatterns = [
     url(r'^admin/import/presidenti/$', anagrafica.viste.admin_import_presidenti),
     url(r'^admin/pulisci/email/$', anagrafica.viste.admin_pulisci_email),
     url(r'^admin/statistiche/$', anagrafica.viste.admin_statistiche),
+    url(r'^admin/report_federazione/$', anagrafica.viste.admin_report_federazione),
 
     url(r'^admin/', include(admin.site.urls)),
     url(r'^login/', include('loginas.urls')),   # Login come utente


### PR DESCRIPTION
## Motivazione

JO-644 e' stato aperto in seguito a delle richieste del personale CRI per la generazione delle statistiche che sono state richieste dalla Federazione relative all'anno concluso 2016.


## Analisi

Piuttosto che generare delle statistiche una-tantum, ho pensato di creare una pagina che genera le statistiche istantanee e per anno solare ad una data qualsiasi, che potra' essere riutilizzata nel futuro. 

Per statistiche instantanee si intede:
- numero di soci per fascia di eta'; 
- numero complessivo di soci.

Per statistiche per anno solare si intende: 
- numero di pratiche di dimissione per decesso.


## Cambiamenti

- Il sistema genera le statistiche istantanee alla data selezionata (`/admin/report_federazione/`)
- Il sistema genera le statistiche relative all'anno solare per i 365 giorni precedenti alla data selezionata (`/admin/report_federazione/`)


## Limitazioni

- Non tutte le statistiche sono facilmente generabili. In particolare, quelle relative alla anzianita' del socio sono particolarmente costose in termini di complessita' temporale, in quanto non precomputiamo l'anzianita'. Se sara' necessario aggiungere queste statistiche, l'elenco dell'elettorato (dove l'anzianita' e' un vincolo) e' un buon luogo dove iniziare una investigazione
- Questa non e' una funzionalita' esposta agli utenti e nessun test funzionale e' stato quindi generato
- In merito a JO-398 (Creare permessi per pagine admin aggiuntive), sara' necessario poter delegare il permesso di usare questa pagina attraverso il sistema di permessi Django


## Testing effettuato

- N/A

