### PR TITLE
Fix per box Vagrant e provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "jdev"
-  config.vm.box_url = "http://vagrant.alacriter.co.uk/vagrant/jdev/"
+    config.vm.box = "ubuntu/trusty64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/config/debug.cnf.sample
+++ b/config/debug.cnf.sample
@@ -4,7 +4,7 @@
 debug = 1
 
 # percorso del file di log relativo alla root del progetto es: ../log/debug.log per i log in /home/gaia/log/debug.log
-;debug_log =
+debug_log = log/debug.log
 
 [production]
 

--- a/config/provision.sh
+++ b/config/provision.sh
@@ -8,9 +8,13 @@
 JORVIK_DIRECTORY=/vagrant
 cd $JORVIK_DIRECTORY
 
-#sudo bash config/provision-psql.sh
-#sudo apt-get upgrade
-#sudo apt-get install -y --force-yes git python3-pip binutils libproj-dev gdal-bin python3-dev libmysqlclient-dev libpq-dev libxml2-dev libxslt-dev
+sudo bash config/provision-psql.sh
+sudo apt-get upgrade
+sudo apt-get install -y --force-yes git python3-pip binutils libproj-dev gdal-bin python3-dev libmysqlclient-dev libjpeg-dev libpq-dev libxml2-dev libxslt-dev
+
+sudo mkdir -p /log/
+sudo chmod a+rw /log/
+
 
 echo "Installazione dei requisiti Python..."
 sudo pip3 install -q -r requirements.txt


### PR DESCRIPTION
## Motivazione

Attualmente non è possibile scaricare il box Vagrant.


## Analisi
Come rilevato nel commit https://github.com/CroceRossaItaliana/jorvik/pull/599/commits/c253cd07d48223e351fc486ba35f49bf801313e9 è necessaria una fix della configurazione del box Vagrant e del provisioning


## Cambiamenti

Modificati solo dei file di configurazione

## Limitazioni

non applicabile


## Testing effettuato

test manuale tramite l'esecuzione del comando Vagrant up --provision