### PR TITLE
JO-642: Aggiungi controllo su ritirate

### DIFF
--- a/anagrafica/tests.py
+++ b/anagrafica/tests.py
@@ -1425,8 +1425,28 @@ class TestAnagrafica(TestCase):
         self.assertEqual(da_trasferire.appartenenze_attuali(membro=Appartenenza.VOLONTARIO, sede=sede1).count(), 1)
         self.assertEqual(da_trasferire.appartenenze_attuali(membro=Appartenenza.VOLONTARIO, sede=sede2).count(), 0)
 
+        self.assertEqual(Trasferimento.con_esito_ok().count(), 0)
+        self.assertEqual(Trasferimento.con_esito_pending().count(), 1)
+        self.assertEqual(Trasferimento.con_esito_ritirata().count(), 0)
+
+        trasf.ritirata = True
+        trasf.save()
+        Autorizzazione.gestisci_automatiche()
+        self.assertEqual(Trasferimento.con_esito_ok().count(), 0)
+        self.assertEqual(Trasferimento.con_esito_pending().count(), 0)
+        self.assertEqual(Trasferimento.con_esito_ritirata().count(), 1)
+
+        trasf.ritirata = False
+        trasf.save()
+        self.assertEqual(Trasferimento.con_esito_ok().count(), 0)
+        self.assertEqual(Trasferimento.con_esito_pending().count(), 1)
+        self.assertEqual(Trasferimento.con_esito_ritirata().count(), 0)
+
         Autorizzazione.gestisci_automatiche()
         autorizzazione.refresh_from_db()
+        self.assertEqual(Trasferimento.con_esito_ok().count(), 1)
+        self.assertEqual(Trasferimento.con_esito_pending().count(), 0)
+        self.assertEqual(Trasferimento.con_esito_ritirata().count(), 0)
 
         self.assertEqual(5, len(mail.outbox))
         destinatari_verificati = 0

--- a/base/models.py
+++ b/base/models.py
@@ -333,15 +333,15 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
         self._invia_notifica(modello, oggetto, auto)
 
     def controlla_concedi_automatico(self):
-        if self.scadenza and self.concessa is None and self.scadenza < now():
+        if self.scadenza and self.concessa is None and self.scadenza < now() and not self.oggetto.ritirata:
             self.concedi(auto=True)
 
     def controlla_nega_automatico(self):
-        if self.scadenza and self.concessa is None and self.scadenza < now():
+        if self.scadenza and self.concessa is None and self.scadenza < now() and not self.oggetto.ritirata:
             self.nega(auto=True)
 
     def automatizza(self, concedi=None, scadenza=None):
-        if concedi:
+        if concedi and not self.oggetto.ritirata:
             self.tipo_gestione = concedi
             self.scadenza = calcola_scadenza(scadenza)
             self.save()
@@ -891,7 +891,7 @@ class Token(ModelloSemplice, ConMarcaTemporale):
                 return False
         except cls.DoesNotExist:
             return False
-    
+
     class Meta:
         permissions = (
             ("view_token", "Can view token"),


### PR DESCRIPTION
## Motivazione

L'approvazione automatica delle autorizzazioni ignora il flag ``ritirata``
Vedere https://jira.sviluppo-gaia.ovh/browse/JO-642


## Analisi

Mancava il controllo sullo stato ritirata dell'oggetto dell'autorizzazione


## Cambiamenti

Inserito controllo sul ritorno


## Testing effettuato

Aggiunti test per verificare lo stato delle richieste ritirate
