### PR TITLE
JO-653: Aggiunta delle riserve agli oggetti a cui una persona ha accesso

### DIFF
--- a/anagrafica/permessi/espansioni.py
+++ b/anagrafica/permessi/espansioni.py
@@ -28,12 +28,13 @@ Questo file gestisce la espansione dei permessi in Gaia.
 
 
 def espandi_persona(persona, al_giorno=None):
-    from anagrafica.models import Persona, Appartenenza, Trasferimento, Estensione
+    from anagrafica.models import Persona, Appartenenza, Trasferimento, Estensione, Riserva
     from ufficio_soci.models import Quota, Tesserino
     try:
         return [
             (LETTURA,   Trasferimento.objects.filter(persona=persona)),
             (LETTURA,   Estensione.objects.filter(persona=persona)),
+            (LETTURA,   Riserva.objects.filter(persona=persona)),
             (LETTURA,   Quota.objects.filter(persona=persona)),
             (LETTURA,   Tesserino.objects.filter(persona=persona)),
         ]


### PR DESCRIPTION
## Motivazione

Nessun utente in gaia riesce ad accedere alle richieste di riserva di riserve passate. Quando clicca su scarica pdf ottiene errore permessi.

https://jira.sviluppo-gaia.ovh/browse/JO-653 per i dettagli

## Analisi

Nel codice attuale mancava completamento l'accesso alle proprie riserve 
(vedi https://jira.sviluppo-gaia.ovh/browse/JO-653) se funzionava prima era probabilmente dovuto ad uno dei tanti problemi risolti con la corretta chiusura di deleghe, permessi etc


## Cambiamenti

I permessi della persona sui suoi oggetti includono adesso anche le riserve

## Limitazioni


## Testing effettuato

Test manuale

