### PR TITLE
JO-627: Le sedi sono correttamente espanse in VolontarioSedeAutocompletamento

### DIFF
--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -113,7 +113,7 @@ class SostenitoreAutocompletamento(PersonaAutocompletamento):
 
 class VolontarioSedeAutocompletamento(PersonaAutocompletamento):
     def choices_for_request(self):
-        sedi = [d.oggetto for d in self.request.user.persona.deleghe_attuali(tipo__in=(UFFICIO_SOCI, UFFICIO_SOCI_UNITA))]
+        sedi = self.request.user.persona.sedi_deleghe_attuali(tipo__in=(UFFICIO_SOCI, UFFICIO_SOCI_UNITA), espandi=True)
         self.choices = self.choices.filter(Appartenenza.query_attuale(membro=Appartenenza.VOLONTARIO, sede__in=sedi).via("appartenenze"))
         return super(VolontarioSedeAutocompletamento, self).choices_for_request()
 

--- a/anagrafica/tests.py
+++ b/anagrafica/tests.py
@@ -2457,6 +2457,38 @@ class TestAnagrafica(TestCase):
         self.assertNotContains(response, '{}<'.format(sede3.nome))
         self.assertNotContains(response, '{}<'.format(sede4.nome))
 
+    def test_autocomplete_volontari_sedi(self):
+        presidente = crea_persona()
+        persona, sede1, appartenenza = crea_persona_sede_appartenenza(presidente=presidente)
+        sede2 = crea_sede(genitore=sede1)
+        sede2.nome = '2sede'
+        sede2.save()
+        sede2b = crea_sede(genitore=sede2, estensione=TERRITORIALE)
+        sede2b.nome = '2bsede'
+        sede2b.save()
+
+        crea_utenza(persona, email=email_fittizzia())
+        Delega.objects.create(persona=persona, tipo=UFFICIO_SOCI, oggetto=sede2, inizio=poco_fa())
+
+        persona_sede1 = crea_persona()
+        persona_sede1.nome = 'PersonaSede 1'
+        persona_sede1.save()
+        Appartenenza.objects.create(persona=persona_sede1, sede=sede1, inizio=poco_fa())
+        persona_sede2 = crea_persona()
+        persona_sede2.nome = 'PersonaSede 2'
+        persona_sede2.save()
+        Appartenenza.objects.create(persona=persona_sede2, sede=sede2, inizio=poco_fa())
+        persona_sede2b = crea_persona()
+        persona_sede2b.nome = 'PersonaSede 2b'
+        persona_sede2b.save()
+        Appartenenza.objects.create(persona=persona_sede2b, sede=sede2b, inizio=poco_fa())
+
+        self.client.login(email=persona.utenza.email, password='prova')
+        response = self.client.get('/autocomplete/VolontarioSedeAutocompletamento/?q=PersonaSede')
+        self.assertNotContains(response, persona_sede1)
+        self.assertContains(response, persona_sede2)
+        self.assertContains(response, persona_sede2b)
+
 
 class TestFunzionaliAnagrafica(TestFunzionale):
 


### PR DESCRIPTION
## Motivazione

Il delegato US del comitato deve poter registrare le quote di tutto il comitato (comprese le quote di quei volontari delle unità territoriali). 
All'interno dei comitati, le deleghe di comitato hanno potere su tutto il comitato, le deleghe a livello di unità territoriale hanno potere sulla singola unitò territoriale. Questo non sta avvedendo.

Vedere https://jira.sviluppo-gaia.ovh/browse/JO-627 per il dettaglio


## Analisi

In VolontarioSedeAutocompletamento non è attivata l'espansione delle sedi, pertanto nel form di selezione degli utenti per il pagamento quote non sono selezionati gli utenti delle sedi "sottostanti"


## Cambiamenti

Attivata l'espansione delle sedi nella view di autocompletamento. Questa modifica permette l'accesso a tutti i soci su cui l'utente ha effettivamente poteri US anche se in sedi "sottostanti" quella in cui ha la delega

## Limitazioni

-

## Testing effettuato

Test di regressione per verificare la corretta espansione delle sedi e relativo autocompletamento degli utenti
