### PR TITLE
JO-612: WiP - Espandi permessi US anche su sedi non attive

### DIFF
--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -1730,10 +1730,10 @@ class Sede(ModelloAlbero, ConMarcaTemporale, ConGeolocalizzazione, ConVecchioID,
 
     def __str__(self):
         if self.estensione == TERRITORIALE and self.genitore is not None:
-            return "%s: %s" % (self.genitore.nome, self.nome,)
+            return "%s: %s%s" % (self.genitore.nome, self.nome, ' [non attiva]' if not self.attiva else '')
 
         else:
-            return "%s" % (self.nome,)
+            return "%s%s" % (self.nome, ' [non attiva]' if not self.attiva else '')
 
     def presidente(self):
         return self.comitato.delegati_attuali(tipo=PRESIDENTE).first()

--- a/anagrafica/permessi/funzioni.py
+++ b/anagrafica/permessi/funzioni.py
@@ -111,14 +111,16 @@ def permessi_ufficio_soci(sede):
     """
     Permessi della delega di UFFICIO SOCI.
 
+    Questo ritorna **anche** le sedi non più attive
+
     :param sede: Sede di cui si e' ufficio soci.
     :return: Lista di permessi.
     """
     from anagrafica.costanti import REGIONALE
     return [
-        (RUBRICA_UFFICIO_SOCI,  sede.espandi(includi_me=True, pubblici=True)),
-        (GESTIONE_SOCI,         sede.espandi(includi_me=True)),
-        (ELENCHI_SOCI,          sede.espandi(includi_me=True, pubblici=True)),
+        (RUBRICA_UFFICIO_SOCI,  sede.espandi(includi_me=True, pubblici=True, ignora_disattive=False)),
+        (GESTIONE_SOCI,         sede.espandi(includi_me=True, ignora_disattive=False)),
+        (ELENCHI_SOCI,          sede.espandi(includi_me=True, pubblici=True, ignora_disattive=False)),
         (EMISSIONE_TESSERINI,   sede.queryset_modello().filter(estensione=REGIONALE)),
     ]
 


### PR DESCRIPTION
## Motivazione

https://jira.sviluppo-gaia.ovh/browse/JO-612

Questa è WiP per verificare insieme se è un approccio possibile alla soluzione del problema


## Analisi

Le sedi attive sono rimosse dall'espansione dei permessi non permettendo più a US l'accesso allo storico. 

## Cambiamenti

Questo è un approccio alla soluzione del problema che permette a US di mantenere tutti i permessi anche sulle sedi non più attive
Aggiunge anche un'etichetta " [non attiva]" a tutte le sedi non attive, ovunque compaiano in Gaia (per il funzionamento del filtro questo è limitato agli elenchi US)

## Limitazioni

-

## Testing effettuato

Manuale (per ora)
