### PR TITLE
JO-543: fix errore in email provvedimento disciplinare

### DIFF
--- a/posta/templates/email_provvedimento.html
+++ b/posta/templates/email_provvedimento.html
@@ -5,7 +5,7 @@
 
 <p class="grassetto">Ciao {{ provvedimento.persona.nome_completo }},</p>
 <p>Questa è una email di attivazione che ti avvisa l'avvenuta registrazione di un provvedimento disciplinare.</p>
-<p>Nello specifico è stato registrato un provvedimento di <strong> _PROVVEDIMENTO </strong> per <strong> {{ provvedimento.motivazione }} </strong>, inizio del provvedimento <strong> {{ provvedimento.inizio }} </strong> e numero di protocollo <strong> {{ provvedimento.protocollo_numero }} </strong>. </p>
+<p>Nello specifico è stato registrato un provvedimento di <strong> {{ provvedimento.get_tipo_display }} </strong> per <strong> {{ provvedimento.motivazione }} </strong>, inizio del provvedimento <strong> {{ provvedimento.inizio }} </strong> e numero di protocollo <strong> {{ provvedimento.protocollo_numero }} </strong>. </p>
 
 <p>Se pensi ci sia stato un errore contatta il tuo presidente</p>
 


### PR DESCRIPTION
## Motivazione

Vedi [JO-543](https://jira.gaia.cri.it/browse/JO-543).

Gli utenti hanno segnalato l'assenza della tipologia di provvedimento disciplinare nelle email di notifica inviate da Gaia. La tipologia e' sostituita dalla stringa `_PROVVEDIMENTO`.


## Analisi

`_PROVVEDIMENTO` e' un placeholder che non e' stato convertito dalla vecchia versione di Gaia.


## Cambiamenti

Il placeholder e' stato convertito per funzionare con il template engine di Django.


## Limitazioni

N/A


## Testing effettuato

Nessun test e' stato effettuato. Questa PR dovra' essere verificata manualmente prima dell'accettazione.

