### PR TITLE
JO-704: Mostra solo riduzioni applicabili al tesseramento in corso

### DIFF
--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -268,19 +268,23 @@ class ModuloElencoIVCM(forms.Form):
 
 class ModuloQuotaGenerico(forms.Form):
     riduzione = forms.ModelChoiceField(
-        label='Riduzione', queryset=Riduzione.objects.all(), widget=forms.RadioSelect,
+        label='Riduzione', queryset=Riduzione.objects.all(),
+        widget=forms.RadioSelect,
         required=False, empty_label='Nessuna'
     )
     importo = forms.FloatField(help_text="Il totale versato in euro, comprensivo dell'eventuale "
                                          "donazione aggiuntiva.")
-    data_versamento = forms.DateField(validators=[valida_data_non_nel_futuro], initial=datetime.date.today)
+    data_versamento = forms.DateField(validators=[valida_data_non_nel_futuro],
+                                      initial=datetime.date.today)
 
     sedi = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, tesseramento=None, **kwargs):
         self.sedi = kwargs.pop('sedi')
         super(ModuloQuotaGenerico, self).__init__(*args, **kwargs)
         self.fields['importo'].widget.attrs['min'] = self.initial.get('importo', 0)
+        if tesseramento:
+            self.fields['riduzione'].queryset = Riduzione.objects.filter(tesseramento=tesseramento)
 
     def clean_quota(self, data):
 

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -876,7 +876,9 @@ def us_quote_nuova(request, me):
             "importo": tesseramento.importo_quota_volontario(),
             "riduzione": None
         }
-        modulo = ModuloQuotaVolontario(request.POST or None, initial=dati_iniziali, sedi=sedi)
+        modulo = ModuloQuotaVolontario(request.POST or None,
+                                       initial=dati_iniziali, sedi=sedi,
+                                       tesseramento=tesseramento)
 
         if modulo and modulo.is_valid():
 


### PR DESCRIPTION
## Motivazione

Vedi [JO-704](https://jira.gaia.cri.it/browse/JO-704).

Nel modulo di registrazione di una nuova quota associativa, vengono mostrate tutte le riduzioni disponibili. Queste includono le riduzioni del tesseramento passato, non piu' applicabili.


## Analisi

Il modulo deve essere modificato in modo tale da mostrare solo le riduzioni applicabili al tesseramento in corso.


## Cambiamenti

Modificato il modulo relativo alla creazione di una quota, cosi' che prenda come argomento opzionale un oggetto `ufficio_soci.Tesseramento`. Quando specificato, le riduzioni mostrate vengono limitate a quelle applicabili al tesseramento specificato.


## Limitazioni

Nessuna. Il modulo Django si occupa di effettuare la validazione lato server (i.e. non e' possibile bypassare il controllo e applicare manualmente una riduzione per l'anno precedente).

@luca-dex e' necessario aggiungere le riduzioni dell'anno in corso dal pannello admin a Gaia in produzione.


## Testing effettuato

Per via di delle problematiche con la nostra interfaccia con Selenium per i test funzionali (relativa al selettore di persone), questa funzionalita' deve essere testata manualmente. @luca-dex si e' offerto 

Dei brevi test manuali sono stati effettuati in locale.


