### PR TITLE
JO-449: Fix presenza in elenchi paganti/non paganti di persone errate

### DIFF
--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -2236,8 +2236,8 @@ class Estensione(ModelloSemplice, ConMarcaTemporale, ConAutorizzazioni, ConPDF):
         if data is None or not isinstance(data, date):
             data = poco_fa()
         data = datetime(data.year, data.month, data.day)
-        self.protocollo_data = modulo.cleaned_data['protocollo_data']
-        self.protocollo_numero = modulo.cleaned_data['protocollo_numero']
+        self.protocollo_data = modulo.cleaned_data['protocollo_data'] if modulo else None
+        self.protocollo_numero = modulo.cleaned_data['protocollo_numero'] if modulo else None
         origine = self.persona.sede_riferimento()
         app = Appartenenza(
             membro=Appartenenza.ESTESO,

--- a/base/utils_tests.py
+++ b/base/utils_tests.py
@@ -12,6 +12,7 @@ from autenticazione.models import Utenza
 from base.geo import Locazione
 from base.utils import poco_fa
 from jorvik.settings import SELENIUM_DRIVER, SELENIUM_URL, SELENIUM_BROWSER
+from ufficio_soci.models import Tesseramento
 
 
 def codice_fiscale(length=16):
@@ -36,6 +37,21 @@ def crea_persona():
     )
     p.refresh_from_db()
     return p
+
+
+def crea_tesseramento(anno=None):
+    anno = anno or poco_fa().year
+    inizio_anno = poco_fa()
+    inizio_anno = inizio_anno.replace(day=1, month=1, hour=0, minute=0, second=0)
+    if anno:
+        inizio_anno = inizio_anno.replace(year=anno)
+    fine_soci = inizio_anno.replace(day=31, month=3, hour=23, minute=59, second=59)
+    t = Tesseramento.objects.create(
+        stato=Tesseramento.APERTO, inizio=inizio_anno, fine_soci=fine_soci,
+        anno=anno, quota_attivo=8, quota_ordinario=8, quota_benemerito=8,
+        quota_aspirante=8, quota_sostenitore=8
+    )
+    return t
 
 
 def crea_utenza(persona, email="mario@rossi.it", password="prova"):

--- a/ufficio_soci/elenchi.py
+++ b/ufficio_soci/elenchi.py
@@ -463,9 +463,10 @@ class ElencoQuote(ElencoVistaSoci):
             origine = tesseramento.non_paganti(attivi=attivi, ordinari=ordinari)  # Persone con quote NON pagate
 
         # Ora filtra per Sede
-        q = Appartenenza.query_attuale(al_giorno=giorno_appartenenza)
+        q = Appartenenza.query_attuale(al_giorno=giorno_appartenenza,
+                                       membro=Appartenenza.VOLONTARIO)
 
-        app = Appartenenza.objects.filter(pk__in=q).filter(sede__in=qs_sedi, membro=Appartenenza.VOLONTARIO)
+        app = Appartenenza.objects.filter(pk__in=q).filter(sede__in=qs_sedi)
         return origine.filter(appartenenze__in=app).annotate(
                 appartenenza_tipo=F('appartenenze__membro'),
                 appartenenza_inizio=F('appartenenze__inizio'),

--- a/ufficio_soci/elenchi.py
+++ b/ufficio_soci/elenchi.py
@@ -4,7 +4,7 @@ from django.utils.encoding import force_text
 
 from anagrafica.models import Persona, Appartenenza, Riserva, Sede, Fototessera, ProvvedimentoDisciplinare
 from attivita.models import Partecipazione
-from base.utils import filtra_queryset, testo_euro
+from base.utils import filtra_queryset, testo_euro, oggi
 from curriculum.models import TitoloPersonale
 from ufficio_soci.forms import ModuloElencoSoci, ModuloElencoElettorato, ModuloElencoQuote, ModuloElencoPerTitoli
 from datetime import date, datetime
@@ -442,11 +442,19 @@ class ElencoQuote(ElencoVistaSoci):
         attivi = membri == modulo.MEMBRI_VOLONTARI
         ordinari = membri == modulo.MEMBRI_ORDINARI
 
+        anno = modulo.cleaned_data['anno']
+
         try:
-            tesseramento = Tesseramento.objects.get(anno=modulo.cleaned_data.get('anno'))
+            tesseramento = Tesseramento.objects.get(anno=anno)
 
         except Tesseramento.DoesNotExist:  # Errore tesseramento anno non esistente
             raise ValueError("Anno di tesseramento non valido o gestito da Gaia.")
+
+        # Dobbiamo ridurre il set a tutti i volontari che sono, al giorno attuale, appartenenti a questa sede
+        # Nel caso di un anno passato, generiamo l'elenco al 31 dicembre. Nel caso dell'anno in corso,
+        # generiamo l'elenco al giorno attuale. Questo e' equivalente a:
+        #  giorno = min(31/dicembre/<anno selezionato>, oggi)
+        giorno_appartenenza = min(date(day=31, month=12, year=anno), oggi())
 
         if modulo.cleaned_data['tipo'] == modulo.VERSATE:
             origine = tesseramento.paganti(attivi=attivi, ordinari=ordinari)  # Persone con quote pagate
@@ -455,7 +463,8 @@ class ElencoQuote(ElencoVistaSoci):
             origine = tesseramento.non_paganti(attivi=attivi, ordinari=ordinari)  # Persone con quote NON pagate
 
         # Ora filtra per Sede
-        q = Appartenenza.query_attuale_in_anno(modulo.cleaned_data.get('anno'))
+        q = Appartenenza.query_attuale(al_giorno=giorno_appartenenza)
+
         app = Appartenenza.objects.filter(pk__in=q).filter(sede__in=qs_sedi, membro=Appartenenza.VOLONTARIO)
         return origine.filter(appartenenze__in=app).annotate(
                 appartenenza_tipo=F('appartenenze__membro'),
@@ -474,7 +483,6 @@ class ElencoQuote(ElencoVistaSoci):
     def template(self):
         modulo = self.modulo_riempito
         return 'us_elenchi_inc_quote.html'
-
 
 
 class ElencoOrdinari(ElencoVistaSoci):

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -94,8 +94,6 @@ class ModuloElencoQuote(forms.Form):
     )
     tipo = forms.ChoiceField(choices=TIPO, initial=DA_VERSARE)
     anno = forms.IntegerField()
-    al_giorno = forms.DateField(help_text="La data alla quale generare l'elenco.",
-                                required=True, initial=datetime.date.today)
 
     def __init__(self, *args, **kwargs):
         super(ModuloElencoQuote, self).__init__(*args, **kwargs)
@@ -105,25 +103,6 @@ class ModuloElencoQuote(forms.Form):
             self.fields['anno'].initial = min(datetime.datetime.now().year, Tesseramento.objects.latest('anno').anno if Tesseramento.objects.all().exists() else 9999)
         except Tesseramento.DoesNotExist:
             pass
-
-    def clean_al_giorno(self):
-        al_giorno = self.cleaned_data.get("al_giorno")
-        if al_giorno > datetime.date.today():
-            raise ValidationError("Impossibile generare elenchi nel futuro.")
-        return al_giorno
-
-    def clean(self):
-        valori = super(ModuloElencoQuote, self).clean()
-
-        anno = valori.get("anno")
-        al_giorno = valori.get("al_giorno")
-
-        if anno and al_giorno:
-            if al_giorno.year < anno:
-                raise ValidationError("Impossibile generare l'elenco per l'anno %d "
-                                      "alla data specificata." % anno)
-
-        return valori
 
 
 class ModuloAggiungiPersona(ModuloStepAnagrafica):

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -94,6 +94,8 @@ class ModuloElencoQuote(forms.Form):
     )
     tipo = forms.ChoiceField(choices=TIPO, initial=DA_VERSARE)
     anno = forms.IntegerField()
+    al_giorno = forms.DateField(help_text="La data alla quale generare l'elenco.",
+                                required=True, initial=datetime.date.today)
 
     def __init__(self, *args, **kwargs):
         super(ModuloElencoQuote, self).__init__(*args, **kwargs)
@@ -103,6 +105,25 @@ class ModuloElencoQuote(forms.Form):
             self.fields['anno'].initial = min(datetime.datetime.now().year, Tesseramento.objects.latest('anno').anno if Tesseramento.objects.all().exists() else 9999)
         except Tesseramento.DoesNotExist:
             pass
+
+    def clean_al_giorno(self):
+        al_giorno = self.cleaned_data.get("al_giorno")
+        if al_giorno > datetime.date.today():
+            raise ValidationError("Impossibile generare elenchi nel futuro.")
+        return al_giorno
+
+    def clean(self):
+        valori = super(ModuloElencoQuote, self).clean()
+
+        anno = valori.get("anno")
+        al_giorno = valori.get("al_giorno")
+
+        if anno and al_giorno:
+            if al_giorno.year < anno:
+                raise ValidationError("Impossibile generare l'elenco per l'anno %d "
+                                      "alla data specificata." % anno)
+
+        return valori
 
 
 class ModuloAggiungiPersona(ModuloStepAnagrafica):

--- a/ufficio_soci/templates/us_elenchi_inc_quote.html
+++ b/ufficio_soci/templates/us_elenchi_inc_quote.html
@@ -24,7 +24,7 @@
 	</div>
 
 
-{$ endblock $}
+{% endblock %}
 
 {% block elenco_intestazione_extra %}
     <th>Quota</th>

--- a/ufficio_soci/templates/us_elenchi_inc_vuoto.html
+++ b/ufficio_soci/templates/us_elenchi_inc_vuoto.html
@@ -1,12 +1,12 @@
 {% extends 'base_bootstrap.html' %}
 
-{% block testo_pre_elenco %} {$ endblock $}
-
 {% block pagina_titolo %}Elenco{% endblock %}
 
 {% block pagina_corpo %}
 
     <div class="container-fluid">
+
+        {% block testo_pre_elenco %} {%  endblock %}
 
         <div class="row allinea-centro">
 
@@ -123,6 +123,7 @@
 
 
         </div>
+
 
         <div class="row">
 

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -31,7 +31,7 @@ from ufficio_soci.models import Tesseramento, Tesserino, Quota, Riduzione
 class TestBase(TestCase):
 
     def setUp(self):
-        super(self, TestBase).setUp()
+        super(TestBase, self).setUp()
 
         self.p, self.s, self.a = crea_persona_sede_appartenenza()
         self.oggi = datetime.date(2015, 1, 1)
@@ -1892,12 +1892,12 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
             self.assertTrue(iframe.is_text_present(volontario.nome))
 
         # Dimetti il volontario
-        sessione_presidente.visit("%s/us/dimissioni/%d/" % (self.live_server_url,
-                                                            volontario.pk))
-        sessione_presidente.select('motivo', Dimissione.VOLONTARIE)
-        sessione_presidente.fill('info', 'Una motivazione di esempio')
-        sessione_presidente.check('trasforma_in_sostenitore')
-        sessione_presidente.find_by_xpath("//button[@type='submit']").first.click()
+        d = Dimissione(
+            persona=volontario, appartenenza=appartenenza,
+            sede=sede, motivo=Dimissione.VOLONTARIE,
+            richiedente=presidente, info="Una motivazione di esempio"
+        )
+        d.applica(trasforma_in_sostenitore=False, invia_notifica=False)
 
         # Vai nuovamente all'elenco quote da pagare
         sessione_presidente.visit("%s/us/quote/" % self.live_server_url)

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -2168,7 +2168,47 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
             # Il volontario e' presente nell'elenco del nuovo comitato
             self.assertTrue(iframe.is_text_present(volontario.nome))
 
+    @freeze_time('2017-01-30')
+    def test_elenco_paganti_estesi_entranti_assenti(self):
+        """
+        Verifica che il volontario avente pagato la quota associativa non appare
+         nell'elenco dei paganti quota presso il comitato dove e' esteso.
+        """
 
+        crea_tesseramento(anno=2017)
+
+        presidente = crea_persona()
+        volontario, sede, appartenenza = crea_persona_sede_appartenenza(presidente=presidente)
+
+        nuovo_presidente = crea_persona()
+        nuova_sede = crea_sede(presidente=nuovo_presidente)
+
+        sessione = self.sessione_utente(persona=nuovo_presidente)
+
+        # Registra una quota per il volontario
+        Quota.nuova(appartenenza=appartenenza, data_versamento=oggi(),
+                    registrato_da=presidente, importo=8, tipo=Quota.QUOTA_SOCIO,
+                    causale="Quota Socio 2017", invia_notifica=False)
+
+        # Creiamo una estensione di servizio
+        e = Estensione(
+            richiedente=volontario, persona=volontario,
+            destinazione=nuova_sede, motivo="Per divertimento"
+        )
+        e.save()
+        e.richiedi(notifiche_attive=False)
+        e.autorizzazione_concessa(modulo=None, auto=True, data=poco_fa(),
+                                  notifiche_attive=True)
+
+        # Vai all'elenco quote versate
+        sessione.visit("%s/us/quote/" % self.live_server_url)
+        with sessione.get_iframe(0) as iframe:
+            iframe.select('tipo', ModuloElencoQuote.VERSATE)
+            iframe.fill('anno', '2017')
+            iframe.find_by_xpath("//button[@type='submit']").first.click()
+
+            # Il volontario NON e' presente nell'elenco del nuovo comitato
+            self.assertTrue(iframe.is_text_not_present(volontario.nome))
 
 
     @freeze_time('2016-11-14')

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -1907,7 +1907,7 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
             iframe.find_by_xpath("//button[@type='submit']").first.click()
 
             # Il volontario NON compare in elenco come dovente pagare quota
-            self.assertFalse(iframe.is_text_present(volontario.nome))
+            self.assertTrue(iframe.is_text_not_present(volontario.nome))
 
 
     @freeze_time('2016-11-14')


### PR DESCRIPTION
## Motivazione

Vedi [JO-449](https://jira.gaia.cri.it/browse/JO-449).

Una serie di segnalazioni riportavano la presenza erronea di alcuni individi all'interno degli elenchi dei soci che hanno pagato la quota, e coloro che devono ancora pagare per l'anno in corso.


## Analisi

Una serie di test funzionali sono stati creati per riprodurre le problematiche segnalate:
- Volontari dimessi nell'anno in corso, che continuano ad apparire nell'elenco dei non paganti;
- Volontari trasferiti presso un altro comitato, che continuano ad apparire nell'elenco dei non paganti;
- Volontari estesi presso il comitato, che appaiono in uno dei due elenchi.

La problematica riguardava la metodologia di generazione dei due elenchi. In particolare, gli elenchi contenevano tutti i soci che:
- avevano una appartenenza valida in un qualunque momento dell'anno selezionato, indipendentemente dallo stato attuale dell'appartenenza (es. volontari trasferiti verso un altro comitato, che erano pero' appartenenti al comitato nel primo giorno dell'anno), inoltre
- avevano un qualunque tipo di appartenenza (inclusa l'estensione di servizio), per via di un errore sintattico che impediva il funzionamento del filtro per mantenere solo i soci volontari non estesi.


## Cambiamenti

Gli elenchi sono stati cambiati con la seguente logica:
- L'elenco e' generato partendo dall'elenco di tutti i soci che hanno pagato la quota, o che non hanno pagato la quota, per il tesseramento selezionato;
- l'elenco e' dunque filtrato, in modo tale che rimangano soltanto i soci che sono appartenenti al comitato:
  - alla data attuale, se l'anno selezionato e' l'anno corrente, oppure,
  - al 31 dicembre dell'anno selezionato, se l'anno selezionato e' nel passato;
- infine, vengono lasciati in elenco sono coloro la cui appartenenza e' di tipo volontario (non in estensione di servizio) presso il comitato.

Data inoltre la confusione relativa ai casi dove un volontario abbia gia' pagato la quota, ma per via di dimissione o trasferimento ad un altro comitato, viene rimosso da questi elenchi, Luca ha aggiunto del testo per chiarire che questo comportamento e' corretto; si tratta infatti di elenchi di soci attivi che devono ancora pagare la quota, o che l'hanno gia' pagata, NON di un elenco di quote pagate che puo' essere invece ottenuto da una sezione separata dell'applicazione riservata ai delegati US.


## Limitazioni

- Prima dell'accettazione e' necessario effettuare del testing/QA manuale su uno degli ambienti di staging, data l'importanza dei cambiamenti;
- E' necessario verificare qualora questi cambiamenti abbiano alcun effetto, o meno, sulle segnalazioni riportate in [JO-227](https://jira.gaia.cri.it/browse/JO-277), "volontario trasferito/dimesso nel 2015 risulta in quote non pagate 2016".


## Testing effettuato

Sono stati aggiunti dei test funzionali per vertificare il funzionamento degli elenchi nei seguenti scenari:
- `test_elenco_non_paganti_dimessi_assenti`: Verifica che i volontari che sono stati dimessi durante l'anno, non compaiano piu' tra i non paganti;
- `test_elenco_non_paganti_trasferiti_uscenti_assenti`: Verifica che i volontari che si sono trasferiti verso un altro comitato, non compaiono piu' tra i non paganti;
- `test_elenco_non_paganti_trasferiti_entranti_presenti`: Verifica che i volontari che si sono trasferiti presso il comitato, ma non hanno pagato la quota per l'anno in corso, appaiono correttamente nell'elenco dei non paganti;
- `test_elenco_non_paganti_estesi_entranti_assenti`: Verifica che i volontari estesi presso il comitato, non appaiono nell'elenco dei non paganti;
- `test_elenco_paganti_dimessi_assenti`: Verifica che i volontari dimessi che hanno pagato la quota associativa, non appaiono piu' nell'elenco dei soci aventi pagato la quota associativa;
- `test_elenco_paganti_trasferiti_uscenti_assenti`: Verifica che i volontari trasferiti presso un altro comitato, che hanno pagato la quota associativa, non appaiono piu' nell'elenco dei soci aventi pagato la quota associativa;
- `test_elenco_paganti_trasferiti_entranti_presenti`: Verfica che i volontari trasferiti presso il comitato, che hanno gia' pagato la quota presso il vecchio comitato, appaiono nell'elenco degli aventi pagato la quota associativa per il tesseramento in corso;
- `test_elenco_paganti_estesi_entranti_assenti`: Verifica che i volontari estesi presso il comitato, che hanno pagato la quota presso un altro comitato, non appaiono nell'elenco degli aventi pagato la quota associativa.