### PR TITLE
Visualizza email di contatto in informazioni delegati US Comitato

### DIFF
--- a/base/templates/base_informazioni_delegati.html
+++ b/base/templates/base_informazioni_delegati.html
@@ -7,7 +7,7 @@
         <ul>
             {% for delega in delegati %}
                 <li>
-                    <a href="mailto:{{ delega.persona.utenza.email }}">
+                    <a href="mailto:{{ delega.persona.email }}">
                         {{ delega.persona.nome_completo }}
                     </a>
                     ({{ delega.get_tipo_display }})


### PR DESCRIPTION
L'email dei delegati US visualizzata in caso di necessità è quella di contatto, se disponibile.

## Motivazione

Ad esempio in caso di necessità di assistenza da parte di un socio nel recupero delle credenziali di accesso attualmente viene visualizzata l'email di accesso invece che quella di contatto (se disponibile). Ho aperto su Kayako #FAH-822-87335 ma credo di non essere stato capito.


## Analisi

L'indirizzo visualizzato è quello dell'utenza invece che quello di contatto.


## Cambiamenti

Si sfrutta la funzione email della Class persona che, se non fraintendo, restituisce l'email corretta (contatto se disponibile, altrimenti accesso, altrimenti "None")


## Limitazioni

Non ho a disposizione istanza per fare i test. Nel caso in cui il delegato US non abbia email (nemmeno per le credenziali) viene probabilmente generato un link non valido invece che evitare completamente di generare il link


## Testing effettuato

Nessuno

