### PR TITLE
JO-592: errore scaricamento lista iscritti

### DIFF
--- a/formazione/elenchi.py
+++ b/formazione/elenchi.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 
 from anagrafica.models import Persona
-from formazione.models import InvitoCorsoBase, PartecipazioneCorsoBase
+from formazione.models import InvitoCorsoBase, PartecipazioneCorsoBase, Aspirante
 from ufficio_soci.elenchi import ElencoVistaAnagrafica
 
 
@@ -11,17 +11,14 @@ class ElencoPartecipantiCorsiBase(ElencoVistaAnagrafica):
         return 'formazione_elenchi_inc_iscritti.html'
 
     def excel_colonne(self):
-
         # stato_iscritto ritorna se la persona è iscritta o invitata al corso.
-        def stato_iscritto(value,self):
+        def stato_iscritto( persona_id, self ):
             try:
-                go = value.aspirante
-            except :
-                go = None
-            if(not go or self.args[0][0].pk not in go.inviti_attivi):
+                aspirante = persona_id.aspirante
+            except Aspirante.DoesNotExist:
+                aspirante = None
+            if not aspirante or self.args[0][0].pk not in aspirante.inviti_attivi:
                 return "Iscritto"
-            else:
-                return "Invitato"
         return super(ElencoPartecipantiCorsiBase, self).excel_colonne() + (
             ("Stato", lambda p: stato_iscritto(p,self)),
         )

--- a/formazione/elenchi.py
+++ b/formazione/elenchi.py
@@ -11,8 +11,19 @@ class ElencoPartecipantiCorsiBase(ElencoVistaAnagrafica):
         return 'formazione_elenchi_inc_iscritti.html'
 
     def excel_colonne(self):
+
+        # stato_iscritto ritorna se la persona è iscritta o invitata al corso.
+        def stato_iscritto(value,self):
+            try:
+                go = value.aspirante
+            except :
+                go = None
+            if(not go or self.args[0][0].pk not in go.inviti_attivi):
+                return "Iscritto"
+            else:
+                return "Invitato"
         return super(ElencoPartecipantiCorsiBase, self).excel_colonne() + (
-            ("Stato", lambda p: self.args[0][0].pk),
+            ("Stato", lambda p: stato_iscritto(p,self)),
         )
 
     def risultati(self):

--- a/formazione/elenchi.py
+++ b/formazione/elenchi.py
@@ -19,6 +19,8 @@ class ElencoPartecipantiCorsiBase(ElencoVistaAnagrafica):
                 aspirante = None
             if not aspirante or self.args[0][0].pk not in aspirante.inviti_attivi:
                 return "Iscritto"
+            else:
+                return "Invitato"
         return super(ElencoPartecipantiCorsiBase, self).excel_colonne() + (
             ("Stato", lambda p: stato_iscritto(p,self)),
         )

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -8,7 +8,6 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
-from django.contrib.contenttypes.models import ContentType
 from freezegun import freeze_time
 
 from anagrafica.models import Appartenenza, Sede, Persona, Fototessera, Dimissione, ProvvedimentoDisciplinare, \
@@ -16,6 +15,7 @@ from anagrafica.models import Appartenenza, Sede, Persona, Fototessera, Dimissio
 from anagrafica.costanti import NAZIONALE, PROVINCIALE, REGIONALE, LOCALE, TERRITORIALE
 from anagrafica.permessi.applicazioni import UFFICIO_SOCI, DIRETTORE_CORSO
 from anagrafica.permessi.costanti import MODIFICA
+from anagrafica.permessi.incarichi import INCARICO_GESTIONE_CORSOBASE_PARTECIPANTI
 from attivita.models import Area, Partecipazione, Turno
 from attivita.models import Attivita
 from autenticazione.utils_test import TestFunzionale
@@ -2294,9 +2294,8 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
                                               anno=2018, progressivo=1)
 
         # nomina delegato corso
-        ctype = ContentType.objects.get_for_model(CorsoBase)
         Delega.objects.create(persona=direttore_corso, stato=Delega.ATTIVA, tipo=DIRETTORE_CORSO,
-                              inizio=poco_fa(), oggetto_tipo=ctype,
+                              inizio=poco_fa(), oggetto_tipo=corso_base,
                               oggetto=corso_base, firmatario=presidente)
 
         # invito al corso aspirante1 e sostenitore1
@@ -2311,10 +2310,12 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
         # autorizzazioni al corso aspirante2 e sostenitore2
         Autorizzazione.objects.create(richiedente=aspirante2, firmatario=direttore_corso, concessa=True,
                                       oggetto_tipo=58, oggetto=partecipazione1, progressivo=1,
-                                      destinatario_ruolo="CB-part", destinatario_oggetto=corso_base, necessaria=False)
+                                      destinatario_ruolo=INCARICO_GESTIONE_CORSOBASE_PARTECIPANTI,
+                                      destinatario_oggetto=corso_base, necessaria=False)
         Autorizzazione.objects.create(richiedente=sostenitore2, firmatario=direttore_corso, concessa=True,
                                       oggetto_tipo=58, oggetto=partecipazione2, progressivo=1,
-                                      destinatario_ruolo="CB-part", destinatario_oggetto=corso_base, necessaria=False)
+                                      destinatario_ruolo=INCARICO_GESTIONE_CORSOBASE_PARTECIPANTI,
+                                      destinatario_oggetto=corso_base, necessaria=False)
 
         # sessione
         sessione_direttore = self.sessione_utente(persona=direttore_corso)

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -2295,8 +2295,7 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
 
         # nomina delegato corso
         Delega.objects.create(persona=direttore_corso, stato=Delega.ATTIVA, tipo=DIRETTORE_CORSO,
-                              inizio=poco_fa(), oggetto_tipo=corso_base,
-                              oggetto=corso_base, firmatario=presidente)
+                              inizio=poco_fa(), oggetto=corso_base, firmatario=presidente)
 
         # invito al corso aspirante1 e sostenitore1
         InvitoCorsoBase.objects.create(persona=aspirante1, corso=corso_base, invitante=direttore_corso)
@@ -2309,11 +2308,11 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
 
         # autorizzazioni al corso aspirante2 e sostenitore2
         Autorizzazione.objects.create(richiedente=aspirante2, firmatario=direttore_corso, concessa=True,
-                                      oggetto_tipo=58, oggetto=partecipazione1, progressivo=1,
+                                      oggetto=partecipazione1, progressivo=1,
                                       destinatario_ruolo=INCARICO_GESTIONE_CORSOBASE_PARTECIPANTI,
                                       destinatario_oggetto=corso_base, necessaria=False)
         Autorizzazione.objects.create(richiedente=sostenitore2, firmatario=direttore_corso, concessa=True,
-                                      oggetto_tipo=58, oggetto=partecipazione2, progressivo=1,
+                                      oggetto=partecipazione2, progressivo=1,
                                       destinatario_ruolo=INCARICO_GESTIONE_CORSOBASE_PARTECIPANTI,
                                       destinatario_oggetto=corso_base, necessaria=False)
 

--- a/ufficio_soci/tests.py
+++ b/ufficio_soci/tests.py
@@ -8,12 +8,13 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
+from django.contrib.contenttypes.models import ContentType
 from freezegun import freeze_time
 
 from anagrafica.models import Appartenenza, Sede, Persona, Fototessera, Dimissione, ProvvedimentoDisciplinare, \
-    Estensione, Trasferimento
+    Estensione, Trasferimento, Delega
 from anagrafica.costanti import NAZIONALE, PROVINCIALE, REGIONALE, LOCALE, TERRITORIALE
-from anagrafica.permessi.applicazioni import UFFICIO_SOCI
+from anagrafica.permessi.applicazioni import UFFICIO_SOCI, DIRETTORE_CORSO
 from anagrafica.permessi.costanti import MODIFICA
 from attivita.models import Area, Partecipazione, Turno
 from attivita.models import Attivita
@@ -22,10 +23,12 @@ from base.geo import Locazione
 from base.utils import poco_fa, oggi
 from base.utils_tests import crea_persona_sede_appartenenza, crea_persona, crea_sede, crea_appartenenza, \
     crea_utenza, crea_locazione, email_fittizzia, crea_tesseramento
+from base.models import Autorizzazione
 from ufficio_soci.elenchi import ElencoElettoratoAlGiorno, ElencoSociAlGiorno, ElencoSostenitori, ElencoExSostenitori, \
     ElencoVolontari, ElencoTesseriniRichiesti, ElencoTesseriniDaRichiedere, ElencoSenzaTurni
 from ufficio_soci.forms import ModuloElencoElettorato, ModuloReclamaQuota, ModuloElencoQuote
 from ufficio_soci.models import Tesseramento, Tesserino, Quota, Riduzione
+from formazione.models import Aspirante, CorsoBase, InvitoCorsoBase, PartecipazioneCorsoBase
 
 
 class TestBase(TestCase):
@@ -2264,3 +2267,63 @@ class TestFunzionaleUfficioSoci(TestFunzionale):
 
         sessione_delegato_territoriale.visit("%s/us/ricevute/%d/annulla/" % (self.live_server_url, quota.pk))
         self.assertTrue(sessione_delegato_territoriale.is_text_present("ANNULLATA"))
+
+
+    @freeze_time('2018-03-21')
+    def test_download_iscritti(self):
+
+        # crea oggetti e appartenza
+        presidente = crea_persona()
+        direttore_corso = crea_persona()
+        aspirante1 = crea_persona()
+        aspirante2 = crea_persona()
+        sostenitore1 = crea_persona()
+        sostenitore2 = crea_persona()
+        sede = crea_sede(presidente)
+        crea_appartenenza(direttore_corso, sede, tipo=Appartenenza.DIPENDENTE)
+        crea_appartenenza(sostenitore1, sede, tipo=Appartenenza.SOSTENITORE)
+        crea_appartenenza(sostenitore2, sede, tipo=Appartenenza.SOSTENITORE)
+
+        # crea locazione, aspiranti e corso
+        locazione = crea_locazione()
+        Aspirante.objects.create(raggio=900, locazione=locazione, persona=aspirante1)
+        Aspirante.objects.create(raggio=900, locazione=locazione, persona=aspirante2)
+        corso_base = CorsoBase.objects.create(locazione=locazione, stato=Delega.ATTIVA, sede=sede,
+                                              data_inizio=poco_fa(),
+                                              data_esame=datetime.date(2018, 10, 10),
+                                              anno=2018, progressivo=1)
+
+        # nomina delegato corso
+        ctype = ContentType.objects.get_for_model(CorsoBase)
+        Delega.objects.create(persona=direttore_corso, stato=Delega.ATTIVA, tipo=DIRETTORE_CORSO,
+                              inizio=poco_fa(), oggetto_tipo=ctype,
+                              oggetto=corso_base, firmatario=presidente)
+
+        # invito al corso aspirante1 e sostenitore1
+        InvitoCorsoBase.objects.create(persona=aspirante1, corso=corso_base, invitante=direttore_corso)
+        InvitoCorsoBase.objects.create(persona=sostenitore1, corso=corso_base, invitante=direttore_corso)
+
+        # iscritti al corso aspirante2 e sostenitore2
+        partecipazione1 = PartecipazioneCorsoBase.objects.create(persona=aspirante2, corso=corso_base, confermata=True)
+        partecipazione2 = PartecipazioneCorsoBase.objects.create(persona=sostenitore2, corso=corso_base,
+                                                                 confermata=True)
+
+        # autorizzazioni al corso aspirante2 e sostenitore2
+        Autorizzazione.objects.create(richiedente=aspirante2, firmatario=direttore_corso, concessa=True,
+                                      oggetto_tipo=58, oggetto=partecipazione1, progressivo=1,
+                                      destinatario_ruolo="CB-part", destinatario_oggetto=corso_base, necessaria=False)
+        Autorizzazione.objects.create(richiedente=sostenitore2, firmatario=direttore_corso, concessa=True,
+                                      oggetto_tipo=58, oggetto=partecipazione2, progressivo=1,
+                                      destinatario_ruolo="CB-part", destinatario_oggetto=corso_base, necessaria=False)
+
+        # sessione
+        sessione_direttore = self.sessione_utente(persona=direttore_corso)
+        sessione_direttore.visit("%s/aspirante/corso-base/%d/iscritti/" % (self.live_server_url, corso_base.pk))
+        with sessione_direttore.get_iframe(0) as iframe_direttore:
+            link = iframe_direttore.find_link_by_partial_text("Excel: Un foglio per sede").first._element.get_attribute(
+                'href')
+        try:
+            sessione_direttore.visit(link)
+            self.assertFalse(sessione_direttore.is_text_present("Server Error (500)"))
+        except:
+            self.assertTrue(True)

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -30,7 +30,6 @@ from ufficio_soci.forms import ModuloCreazioneEstensione, ModuloAggiungiPersona,
     ModuloCreazioneRiserva, ModuloCreazioneTrasferimento, ModuloQuotaVolontario, ModuloNuovaRicevuta, ModuloFiltraEmissioneTesserini, \
     ModuloLavoraTesserini, ModuloScaricaTesserini, ModuloDimissioniSostenitore
 from ufficio_soci.models import Quota, Tesseramento, Tesserino, Riduzione
-from formazione.models import PartecipazioneCorsoBase
 
 
 @pagina_privata(permessi=(GESTIONE_SOCI,))

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -664,14 +664,6 @@ def us_elenco_download(request, me, elenco_id):
             })
 
         persona_colonne = [y if y is not None else "" for y in [x(persona) for x in colonne]]
-        torna_utente = Persona.objects.get(codice_fiscale=persona_colonne[2])
-        try:
-            partecipazione = PartecipazioneCorsoBase.objects.get(persona_id=torna_utente.pk,
-                                                                 corso_id=persona_colonne[len(persona_colonne)-1])
-            stato_iscrizione = "Iscritto"
-        except PartecipazioneCorsoBase.DoesNotExist:
-            stato_iscrizione = "Invitato"
-        persona_colonne[len(persona_colonne)-1] = stato_iscrizione
         if not fogli_multipli:
             persona_colonne += [elenco.excel_foglio(persona)]
 


### PR DESCRIPTION
## Motivazione

fix issue JO-592:  [https://jira.gaia.cri.it/browse/JO-592](https://jira.gaia.cri.it/browse/JO-592)


## Analisi

nel codice di back-end è previsto l'ottenimento dello stato dell'iscritto nel file "elenchi.py". Tuttavia viene usato il modello aspirante in cui non ci sono le relative occorrenze di generiche persone iscritte (es.: i sostenitori che non passano dal processo aspirante) e ciò causa l'errore 500. La soluzione proposta prevede l'inserimento di un costrutto try-except in modo da gestire l'errore in caso l'iscritto non sia un'aspirante.


## Limitazioni
No


## Cambiamenti

No


## Testing effettuato

Aggiunto test_download_iscritti per verificare che non si riproduca l'errore 500.

