### PR TITLE
JO-316: data migrations richieste di attività pendenti

### DIFF
--- a/attivita/migrations/0018_negazione_automatica_vecchie.py
+++ b/attivita/migrations/0018_negazione_automatica_vecchie.py
@@ -4,19 +4,30 @@ from __future__ import unicode_literals
 from datetime import datetime, date, timedelta
 
 from django.db import migrations, models
+from django.db.models import Q
 from anagrafica.permessi.incarichi import INCARICO_GESTIONE_ATTIVITA_PARTECIPANTI
 
 
 def nega_partecipazioni_vecchie(apps, schema_editor):
 
+    Partecipazione = apps.get_model("attivita", "Partecipazione")
     Autorizzazione = apps.get_model("base", "Autorizzazione")
 
-    # Autorizzazioni attività di partecipazione, senza esito ed escludendo quelle già negate.
-    autorizzazioni = Autorizzazione.objects.filter(concessa__isnull=True,
-                                                   destinatario_ruolo=INCARICO_GESTIONE_ATTIVITA_PARTECIPANTI
-                                                  ).exclude(tipo_gestione="N")
+    # Ottieni ContentType per Partecipazione
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    tipo = ContentType.objects.get_for_model(Partecipazione)
 
-    # Impostazione scadenza su data attuale e negazione automatica.
+    # Costruisci primo oggetto Q, partecipazioni e relative autorizzazioni
+    q1 = Q(confermata=False, ritirata=False, pk__in=Autorizzazione.objects.filter(oggetto_tipo__pk=tipo.id)
+           .values_list('oggetto_id', flat=True))
+    # Costruisci secondo oggetto Q, ci possono essere due autorizzazioni per una partecipazione
+    q2 = ~Q(pk__in=Autorizzazione.objects.filter(oggetto_tipo__pk=tipo.id, concessa=False)
+                                                 .values_list('oggetto_id', flat=True))
+
+    # Autorizzazioni di partecipazioni pendenti
+    autorizzazioni = Autorizzazione.objects.filter(oggetto_tipo_id=tipo.id,
+                                                   oggetto_id__in=Partecipazione.objects.filter(q1,q2)
+                                                   .values_list('id', flat=True))
     autorizzazioni.update(scadenza=datetime.now(), tipo_gestione="N")
 
 

--- a/attivita/migrations/0018_negazione_automatica_vecchie.py
+++ b/attivita/migrations/0018_negazione_automatica_vecchie.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from datetime import datetime, date, timedelta
 
 from django.db import migrations, models
-from django.db.models import Q
 
 
 def nega_partecipazioni_vecchie(apps, schema_editor):

--- a/attivita/migrations/0018_negazione_automatica_vecchie.py
+++ b/attivita/migrations/0018_negazione_automatica_vecchie.py
@@ -4,38 +4,20 @@ from __future__ import unicode_literals
 from datetime import datetime, date, timedelta
 
 from django.db import migrations, models
+from anagrafica.permessi.incarichi import INCARICO_GESTIONE_ATTIVITA_PARTECIPANTI
 
 
 def nega_partecipazioni_vecchie(apps, schema_editor):
 
-    Partecipazione = apps.get_model("attivita", "Partecipazione")
     Autorizzazione = apps.get_model("base", "Autorizzazione")
 
-    partecipzioni_pendenti = Partecipazione.objects.filter(confermata=False, ritirata=False, automatica=False)
-    totale = partecipzioni_pendenti.count()
-    print("  => 0018 trovate %d partecipazioni di attivita pendenti" % (totale))
+    # Autorizzazioni attività di partecipazione, senza esito ed escludendo quelle già negate.
+    autorizzazioni = Autorizzazione.objects.filter(concessa__isnull=True,
+                                                   destinatario_ruolo=INCARICO_GESTIONE_ATTIVITA_PARTECIPANTI
+                                                  ).exclude(tipo_gestione="N")
 
-    autorizzazioni_con_scadenza = 0
-    autorizzazioni_senza_scadenza = 0
-    for partecipazione in partecipzioni_pendenti:
-        # Autorizzazioni senza esito della partecipazione pendente
-        autorizzazioni_partecipazione = Autorizzazione.objects.filter(oggetto_id=partecipazione.pk, concessa=None)
-        for autorizzazione in autorizzazioni_partecipazione:
-            # Se l'autorizzazione ha una scadenza
-            if autorizzazione.scadenza:
-                # Imposta negazione automatica per autorizzazione con scadenza
-                if(autorizzazione.tipo_gestione != 'N'):
-                    autorizzazione.tipo_gestione = 'N'
-                    autorizzazione.save()
-                    autorizzazioni_con_scadenza += 1
-            else:
-                # Imposta negazione automatica e scadenza 30gg per autorizzazione senza scadenza
-                autorizzazione.tipo_gestione = 'N'
-                autorizzazione.scadenza = autorizzazione.creazione + timedelta(days=30)
-                autorizzazione.save()
-                autorizzazioni_senza_scadenza += 1
-
-    print("  ==> 0018 modificate %d autorizzazioni con scadenza e %d autorizzazioni senza scadenza" % (autorizzazioni_con_scadenza, autorizzazioni_senza_scadenza))
+    # Impostazione scadenza su data attuale e negazione automatica.
+    autorizzazioni.update(scadenza=datetime.now(), tipo_gestione="N")
 
 
 class Migration(migrations.Migration):

--- a/attivita/migrations/0018_negazione_automatica_vecchie.py
+++ b/attivita/migrations/0018_negazione_automatica_vecchie.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import datetime, date, timedelta
+
+from django.db import migrations, models
+from django.db.models import Q
+
+
+def nega_partecipazioni_vecchie(apps, schema_editor):
+
+    Partecipazione = apps.get_model("attivita", "Partecipazione")
+    Autorizzazione = apps.get_model("base", "Autorizzazione")
+
+    partecipzioni_pendenti = Partecipazione.objects.filter(confermata=False, ritirata=False, automatica=False)
+    totale = partecipzioni_pendenti.count()
+    print("  => 0018 trovate %d partecipazioni di attivita pendenti" % (totale))
+
+    autorizzazioni_con_scadenza = 0
+    autorizzazioni_senza_scadenza = 0
+    for partecipazione in partecipzioni_pendenti:
+        # Autorizzazioni senza esito della partecipazione pendente
+        autorizzazioni_partecipazione = Autorizzazione.objects.filter(oggetto_id=partecipazione.pk, concessa=None)
+        for autorizzazione in autorizzazioni_partecipazione:
+            # Se l'autorizzazione ha una scadenza
+            if autorizzazione.scadenza:
+                # Imposta negazione automatica per autorizzazione con scadenza
+                if(autorizzazione.tipo_gestione != 'N'):
+                    autorizzazione.tipo_gestione = 'N'
+                    autorizzazione.save()
+                    autorizzazioni_con_scadenza += 1
+            else:
+                # Imposta negazione automatica e scadenza 30gg per autorizzazione senza scadenza
+                autorizzazione.tipo_gestione = 'N'
+                autorizzazione.scadenza = autorizzazione.creazione + timedelta(days=30)
+                autorizzazione.save()
+                autorizzazioni_senza_scadenza += 1
+
+    print("  ==> 0018 modificate %d autorizzazioni con scadenza e %d autorizzazioni senza scadenza" % (autorizzazioni_con_scadenza, autorizzazioni_senza_scadenza))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('attivita', '0017_chiudi_attivita_vecchie'),
+        ('base', '0018_autorizzazione_automatica'),
+    ]
+
+    operations = [
+        migrations.RunPython(nega_partecipazioni_vecchie)
+    ]


### PR DESCRIPTION
## Motivazione

Vedi [JO-316](https://jira.gaia.cri.it/browse/JO-316)
È stato richiesto di impostare i dati per le richieste di attività pendenti dopo la chiusura di [JO-237](https://jira.gaia.cri.it/browse/JO-237) tramite una datamigration che imposti i valori corretti (NG_AUTO e scadenza).


## Analisi

Ci sono richieste di partecipazione per vecchie attività ancora pendenti essendo antecedenti all'introduzione della nuova funzionalità su GAIA che permette la configurazione di particolari tipologie di richieste di autorizzazione (approvazione automatica o negazione automatica).
Essendo stata introdotta questa funzionalità in un successivo momento, le vecchie richieste di partecipazione ad un'attività non hanno impostata una data di scadenza (modello Autorizzazione) o se l'hanno è il campo tipo_gestione (modello Autorizzazione) a non essere impostato su negazione automatica.
La soluzione consiste nel popolare il campo scadenza con la data attuale e impostare il campo tipo_gestione su negazione automatica.


## Cambiamenti

Le vecchie richieste di partecipazione alle attività saranno visibili dall'utente come negate e non più come pendenti.


## Testing effettuato

Test effettuato effettuando un data migration e verificando se i campi tipo_gestione e scadenza venivano popolati con i valori voluti.