### PR TITLE
celery: utilizzo di code differenti per i task di invio e processing …

### DIFF
--- a/jorvik/celery.py
+++ b/jorvik/celery.py
@@ -10,6 +10,10 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'jorvik.settings')
 
 app = Celery('jorvik')
 app.conf.update(CELERY_CONF.items('celery'))
+app.conf.task_routes = {
+    'posta.queue.process_queue': {'queue': 'coda_email_accodamento'},
+    'posta.tasks.send': {'queue': 'coda_email_invio'}
+}
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()


### PR DESCRIPTION
Utilizzo di due code separate per i task di celery, al momento i task di invio saturano i worker e lo il task che smista viene lanciato di rado