### PR TITLE
JO-585: filtro per il comitato nelle richieste di emissione di un nuovo tesserino.

### DIFF
--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -413,7 +413,6 @@ class ModuloNuovaRicevuta(forms.Form):
 class ModuloFiltraEmissioneTesserini(forms.Form):
     def __init__(self, *args, sedi, **kwargs):
         super(ModuloFiltraEmissioneTesserini, self).__init__(*args, **kwargs)
-        self.fields['sedi'].initial = sedi
         self.fields['sedi'].queryset = sedi
 
     stato_richiesta = forms.MultipleChoiceField(choices=Tesserino.STATO_RICHIESTA)

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -411,12 +411,10 @@ class ModuloNuovaRicevuta(forms.Form):
 
 
 class ModuloFiltraEmissioneTesserini(forms.Form):
-
-    def __init__(self, *args, **kwargs):
-        sedi = kwargs.pop("sedi")
+    def __init__(self, *args, sedi, **kwargs):
         super(ModuloFiltraEmissioneTesserini, self).__init__(*args, **kwargs)
-        self.fields['sedi'] = forms.ModelMultipleChoiceField(queryset=sedi, initial=sedi)
-        self.sedi = sedi
+        self.fields['sedi'].initial = sedi
+        self.fields['sedi'].queryset = sedi
 
     stato_richiesta = forms.MultipleChoiceField(choices=Tesserino.STATO_RICHIESTA)
     tipo_richiesta = forms.MultipleChoiceField(choices=Tesserino.TIPO_RICHIESTA, initial=(Tesserino.RILASCIO,
@@ -425,7 +423,7 @@ class ModuloFiltraEmissioneTesserini(forms.Form):
     stato_emissione = forms.MultipleChoiceField(choices=Tesserino.STATO_EMISSIONE, initial=(("", Tesserino.STAMPATO,
                                                                                              Tesserino.SPEDITO_CASA,
                                                                                              Tesserino.SPEDITO_SEDE)),)
-    sedi = forms.ModelMultipleChoiceField(queryset='')
+    sedi = forms.ModelMultipleChoiceField(queryset=None)
 
     DATA_RICHIESTA_DESC = '-creazione'
     DATA_RICHIESTA_ASC = 'creazione'
@@ -441,14 +439,6 @@ class ModuloFiltraEmissioneTesserini(forms.Form):
 
     cerca = forms.CharField(initial="", required=False, help_text="(Opzionale) Parte del Codice Fiscale o "
                                                                   " codice tesserino.")
-
-    def clean(self):
-        sedi = self.cleaned_data['sedi']
-
-        sedi_selezionate = [str(selezionate.id) for selezionate in sedi]
-        sedi_possibili = [str(possibili.id) for possibili in self.sedi]
-        if not sedi_selezionate or not set(sedi_selezionate).issubset(sedi_possibili):
-            raise ValidationError("Sede selezionata non permessa.")
 
 
 class ModuloLavoraTesserini(forms.Form):

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -8,7 +8,7 @@ from django.forms import ModelForm
 from django.utils.timezone import now
 
 from anagrafica.forms import ModuloStepAnagrafica
-from anagrafica.models import Estensione, Appartenenza, Persona, Dimissione, Riserva, Trasferimento, Sede
+from anagrafica.models import Estensione, Appartenenza, Persona, Dimissione, Riserva, Trasferimento
 from anagrafica.validators import valida_almeno_14_anni
 from base.utils import rimuovi_scelte, testo_euro
 from ufficio_soci.validators import valida_data_non_nel_futuro

--- a/ufficio_soci/forms.py
+++ b/ufficio_soci/forms.py
@@ -412,6 +412,15 @@ class ModuloNuovaRicevuta(forms.Form):
 
 class ModuloFiltraEmissioneTesserini(forms.Form):
 
+    def __init__(self, *args, **kwargs):
+        sedi = kwargs.pop("sedi")  # passo le sedi permesse
+        sedi_sottosedi = [sede.esplora() for sede in sedi]
+        id_sede = [scelte.id for scelte in sedi_sottosedi[0]]
+        nomi_sede = [scelte.nome_completo for scelte in sedi_sottosedi[0]]
+        scelte_sede = list(zip(id_sede, nomi_sede))
+        super(ModuloFiltraEmissioneTesserini, self).__init__(*args, **kwargs)
+        self.fields['comitato'] = forms.MultipleChoiceField(choices=scelte_sede, initial=id_sede)
+
     stato_richiesta = forms.MultipleChoiceField(choices=Tesserino.STATO_RICHIESTA)
     tipo_richiesta = forms.MultipleChoiceField(choices=Tesserino.TIPO_RICHIESTA, initial=(Tesserino.RILASCIO,
                                                                                           Tesserino.RINNOVO,
@@ -419,6 +428,7 @@ class ModuloFiltraEmissioneTesserini(forms.Form):
     stato_emissione = forms.MultipleChoiceField(choices=Tesserino.STATO_EMISSIONE, initial=(("", Tesserino.STAMPATO,
                                                                                              Tesserino.SPEDITO_CASA,
                                                                                              Tesserino.SPEDITO_SEDE)),)
+    comitato = forms.MultipleChoiceField()
 
     DATA_RICHIESTA_DESC = '-creazione'
     DATA_RICHIESTA_ASC = 'creazione'

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -24,7 +24,7 @@ from posta.utils import imposta_destinatari_e_scrivi_messaggio
 from ufficio_soci.elenchi import ElencoSociAlGiorno, ElencoSostenitori, ElencoVolontari, ElencoOrdinari, \
     ElencoElettoratoAlGiorno, ElencoQuote, ElencoPerTitoli, ElencoDipendenti, ElencoDimessi, ElencoTrasferiti, \
     ElencoVolontariGiovani, ElencoEstesi, ElencoInRiserva, ElencoIVCM, ElencoTesseriniSenzaFototessera, \
-    ElencoTesseriniRichiesti, ElencoTesseriniDaRichiedere, ElencoTesseriniRifiutati, ElencoExSostenitori, ElencoSenzaTurni
+    ElencoTesseriniRichiesti, ElencoTesseriniDaRichiedere, ElencoExSostenitori, ElencoSenzaTurni
 from ufficio_soci.forms import ModuloCreazioneEstensione, ModuloAggiungiPersona, ModuloReclamaAppartenenza, \
     ModuloReclamaQuota, ModuloReclama, ModuloCreazioneDimissioni, ModuloVerificaTesserino, ModuloElencoRicevute, \
     ModuloCreazioneRiserva, ModuloCreazioneTrasferimento, ModuloQuotaVolontario, ModuloNuovaRicevuta, ModuloFiltraEmissioneTesserini, \
@@ -1179,20 +1179,6 @@ def us_tesserini_richiesti(request, me):
 
 
 @pagina_privata
-def us_tesserini_rifiutati(request, me):
-    """
-    Mostra l'elenco dei volontari per i quali è stata rifiutata la
-     richiesta del tesserino.
-    """
-    sedi = me.oggetti_permesso(GESTIONE_SOCI)
-    elenco = ElencoTesseriniRifiutati(sedi)
-    contesto = {
-        "elenco": elenco
-    }
-    return "us_tesserini_rifiutati.html", contesto
-
-
-@pagina_privata
 def us_tesserini_richiedi(request, me, persona_pk=None):
     """
     Effettua la richiesta di tesserino per il volontario.
@@ -1385,24 +1371,6 @@ def us_tesserini_emissione_processa(request, me):
             tesserini.update(valido=valido)
 
             fine = True
-
-            # invio messaggio all'US richiedente se tesserino rifiutato
-            if(stato_richiesta == Tesserino.RIFIUTATO):
-                for i in tesserini:
-                    persona = Persona.objects.get(pk=i.persona.id)
-                    messaggio = Messaggio.costruisci(
-                        oggetto='Richiesta tesserino rifiutata',
-                        modello='email_utente.html',
-                        corpo={"testo": "La richiesta di tesserino del volontario " +
-                                        persona.nome + " " + persona.cognome +
-                                        " è stata rifiutata con il seguente motivo: " +
-                                        modulo.cleaned_data['motivo_rifiutato'] +
-                                        "<br>Puoi visualizzare le richieste rifiutate " +
-                                        "<a href='/us/tesserini/rifiutati/'>cliccando qui</a>"},
-                        allegati=[],
-                        mittente=me,
-                        destinatari=[Persona.objects.get(pk=i.richiesto_da_id)],
-                    )
 
     else:
         modulo = ModuloScaricaTesserini(request.POST if 'tesserini' not in request.POST else None)

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -1277,8 +1277,8 @@ def us_tesserini_emissione(request, me):
     sedi = me.oggetti_permesso(EMISSIONE_TESSERINI)
 
     sedi = Sede.objects.filter(id__in=sedi.values_list('id', flat=True))
-    # Comitati Regionali, Locali e Provinciali.
-    sedi = sedi.espandi(pubblici=True).comitati()
+    # Comitati Locali e Provinciali.
+    sedi = sedi.espandi(pubblici=True).comitati().exclude(estensione=REGIONALE)
 
     tesserini = Tesserino.objects.none()
 

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -7,7 +7,7 @@ from django.db.models import Sum, Q
 from django.shortcuts import redirect, get_object_or_404
 from django.utils.safestring import mark_safe
 
-from anagrafica.costanti import REGIONALE
+from anagrafica.costanti import NAZIONALE, REGIONALE
 from anagrafica.forms import ModuloNuovoProvvedimento
 from anagrafica.models import Appartenenza, Persona, Estensione, ProvvedimentoDisciplinare, Sede, Dimissione, Riserva, \
     Trasferimento
@@ -1278,16 +1278,17 @@ def us_tesserini_emissione(request, me):
 
     sedi = Sede.objects.filter(id__in=sedi.values_list('id', flat=True))
     # Comitati Locali e Provinciali.
-    sedi = sedi.espandi(pubblici=True).comitati().exclude(estensione=REGIONALE)
+    sedi_espandi = sedi.espandi(pubblici=True).comitati().exclude(estensione__in=[NAZIONALE, REGIONALE])
 
     tesserini = Tesserino.objects.none()
 
-    modulo = ModuloFiltraEmissioneTesserini(request.POST or None, sedi = sedi)
+    modulo = ModuloFiltraEmissioneTesserini(request.POST or None, sedi=sedi_espandi)
     modulo_compilato = True if request.POST else False
 
     if modulo.is_valid():
         stato_emissione = modulo.cleaned_data['stato_emissione']
         sedi_selezionate = modulo.cleaned_data['sedi'].espandi(pubblici=True)
+        print(sedi_selezionate)
         stato_emissione_q = Q(stato_emissione__in=stato_emissione)
         if '' in stato_emissione:
             stato_emissione_q |= Q(stato_emissione__isnull=True)

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -1303,13 +1303,10 @@ def us_tesserini_emissione(request, me):
             stato_richiesta__in=modulo.cleaned_data['stato_richiesta']
         ).order_by(modulo.cleaned_data['ordine'])
 
-        # id richiedenti tesserino che hanno delega per le sedi selezionate nel filtro.
-        richiedenti_id = Delega.objects.filter(persona_id__in=tesserini.values_list('richiesto_da', flat=True),
-                                        oggetto_id__in=sedi_selezionate, oggetto_tipo=21)\
-                                        .values_list('persona_id', flat=True)
-        # tesserini richiesti per le sole sedi selezionate.
-        q = Q(richiesto_da__in=tesserini.values_list('richiesto_da', flat=True) and richiedenti_id)
-        tesserini = Tesserino.objects.filter(q)
+        # Ottiene oggetto Q per tutte le appartenenze attuali come Volontario in una delle Sedi selezionate.
+        q = Appartenenza.query_attuale(membro=Appartenenza.VOLONTARIO, sede__in=sedi_selezionate) \
+            .via("persona__appartenenze")
+        tesserini = tesserini.filter(q)
 
     contesto = {
         "tesserini": tesserini,

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -1288,7 +1288,6 @@ def us_tesserini_emissione(request, me):
     if modulo.is_valid():
         stato_emissione = modulo.cleaned_data['stato_emissione']
         sedi_selezionate = modulo.cleaned_data['sedi'].espandi(pubblici=True)
-        print(sedi_selezionate)
         stato_emissione_q = Q(stato_emissione__in=stato_emissione)
         if '' in stato_emissione:
             stato_emissione_q |= Q(stato_emissione__isnull=True)

--- a/ufficio_soci/viste.py
+++ b/ufficio_soci/viste.py
@@ -10,7 +10,7 @@ from django.utils.safestring import mark_safe
 from anagrafica.costanti import REGIONALE
 from anagrafica.forms import ModuloNuovoProvvedimento
 from anagrafica.models import Appartenenza, Persona, Estensione, ProvvedimentoDisciplinare, Sede, Dimissione, Riserva, \
-    Trasferimento, Delega
+    Trasferimento
 from anagrafica.permessi.applicazioni import PRESIDENTE
 from anagrafica.permessi.costanti import GESTIONE_SOCI, ELENCHI_SOCI , ERRORE_PERMESSI, MODIFICA, EMISSIONE_TESSERINI
 from autenticazione.forms import ModuloCreazioneUtenza


### PR DESCRIPTION
## Motivazione

Vedi [JO-585](https://jira.gaia.cri.it/browse/JO-585)
È stata chiesta la possibilità di filtrare le richieste di emissione di un nuovo tesserino per Comitato, in modo da agevolarne la stampa

## Analisi

Data la necessità di un filtro aggiuntivo nella pagina di emissione dei tesserini è stato inserito nel form già esistente un nuovo campo denominato "comitato" in cui vengno passate le sedi permesse ottenute dalla vista us_tesserini_emissione. 


## Cambiamenti

L'utente può filtrare i tesserini in base ai comitati per i quali ha i permessi.


## Testing effettuato

Test effettuati direttamente dalla pagina di emissione dei tesserini, verificando che il filtraggio non restituisca tesserini richiesti da sedi sulle quali non si hanno i permessi.