### PR TITLE
WiP: JO-517: segmento "tutti i volontari di una regione".

### DIFF
--- a/segmenti/models.py
+++ b/segmenti/models.py
@@ -34,6 +34,13 @@ class FiltroSegmentoQuerySet(models.QuerySet):
         :param utente: Utente su cui filtrare gli oggetti
         :return: Queryset filtrato
         """
+        for articolo_segmento in self:
+            # se il segmento è AB ovvero "Tutti i volontari di una regione"
+            if articolo_segmento.segmento == 'AB':
+                sedi = [sede.id for sede in articolo_segmento.sede.esplora()]
+                # se la sede della persona è nella regione
+                if utente.segmenti_collegati[len(utente.segmenti_collegati) - 1]['sede'].id in sedi:
+                    utente.segmenti_collegati[len(utente.segmenti_collegati) - 1]['sede'] = articolo_segmento.sede.esplora()[0]
         filtri = self._get_filtri(utente.segmenti_collegati)
         return self.filter(filtri)
 

--- a/segmenti/segmenti.py
+++ b/segmenti/segmenti.py
@@ -203,6 +203,11 @@ def volontari_con_titolo(queryset):
     return volontari(queryset).filter(titoli_personali__confermata=True)
 
 
+def tutti_i_volontari_di_una_regione(queryset):
+    tutti_volontari = queryset.filter(appartenenze__membro=Appartenenza.VOLONTARIO)
+    return _appartenenze_attive(tutti_volontari)
+
+
 NOMI_SEGMENTI = (
     ('A', 'Tutti gli utenti di Gaia'),
     ('B', 'Volontari'),
@@ -231,6 +236,7 @@ NOMI_SEGMENTI = (
     ('Y', 'Delegati Autoparco'),
     ('Z', 'Delegati Formazione'),
     ('AA', 'Volontari aventi un dato titolo'),
+    ('AB', 'Tutti i volontari di una regione'),
 )
 
 
@@ -264,4 +270,5 @@ SEGMENTI = {
     'Y':              delegati_autoparco,
     'Z':              delegati_formazione,
     'AA':             volontari_con_titolo,
+    'AB':             tutti_i_volontari_di_una_regione,
 }


### PR DESCRIPTION
## Motivazione

Vedi [JO-517](https://jira.gaia.cri.it/browse/JO-517)


## Analisi

Viene introdotto un nuovo segmento "AB" relativo a tutti i volontari di una regione. In fase di creazione del segmento dell'articolo viene selezionata la Sede e quest'ultima viene espansa in modo che anche i Volontari dei sotto comitati possano vedere l'articolo.


## Cambiamenti

Selezionando il segmento "tutti i volontari di una regione" e scegliendo una sede regionale, tutti i volontari dei sotto comitati vedranno l'articolo. Non è necessario indicare, ad uno ad uno, gli ID di ciascun comitato della regione.


## Testing effettuato

Test effettuati manualmente creando dei volontari, delle sedi, degli articoli e associando il relativo segmento "tutti i volontari di una regione". Nel tab Articoli, gli articoli erano visibili solo se il Volontario faceva parte del comitato regionale o dei sotto comitati.