### PR TITLE
JO-340: modifica template "Aperta a"

### DIFF
--- a/attivita/templates/attivita_scheda_informazioni.html
+++ b/attivita/templates/attivita_scheda_informazioni.html
@@ -93,11 +93,11 @@
                 <div class="panel-body">
                     Tutti i Volontari di
                     <strong>
-                        <a href="{{ attivita.sede.url }}" target="_new">
-                            {{ attivita.sede.nome }}
+                        <a href="{{ attivita.estensione.url }}" target="_new">
+                            {{ attivita.estensione.nome }}
                         </a>
                     </strong><br />
-                    ({{ attivita.sede.get_estensione_display }} e sottostanti)
+                    ({{ attivita.estensione.get_estensione_display }} e sottostanti)
                 </div>
 
             </div>

--- a/attivita/templates/attivita_scheda_informazioni.html
+++ b/attivita/templates/attivita_scheda_informazioni.html
@@ -91,13 +91,17 @@
                 </div>
 
                 <div class="panel-body">
-                    Tutti i Volontari di
-                    <strong>
+                    {% if attivita.estensione %}
+                        Tutti i Volontari di
+                        <strong>
                         <a href="{{ attivita.estensione.url }}" target="_new">
                             {{ attivita.estensione.nome }}
                         </a>
-                    </strong><br />
-                    ({{ attivita.estensione.get_estensione_display }} e sottostanti)
+                        </strong><br />
+                        ({{ attivita.estensione.get_estensione_display }} e sottostanti)
+                    {% else %}
+                        Nessuno.
+                    {% endif %}
                 </div>
 
             </div>


### PR DESCRIPTION
## Motivazione

Vedi [JO-340](https://jira.gaia.cri.it/browse/JO-340)
l'anomalia riscontrata non è presente. Viene però mostrara un'informazione errata nel template delle informazioni relative all'attività.


## Analisi

Nella pagina delle informazioni dell'attività nel box "Aperto a" l'informazione è presa dalla sede. Siccome nella gestione dell'attività viene selezionata l'estensione ovvero a chi dovrebbe essere aperta, l'informazione sull'estensione che va inserita nel template.


## Cambiamenti

L'utente vede correttamente a chi è aperta l'attività


## Testing effettuato

Test effettuati andando a vedere direttamente le pagine delle informazioni di più atitvità create,  modificandone anche l'estensione.