### PR TITLE
JO-535: accesso in lettura a tutti i volontari

### DIFF
--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -33,13 +33,8 @@ class PersonaAutocompletamento(AutocompletamentoBase):
 
     def choices_for_request(self, filtra_per_sede=True):
 
-        # Le mie sedi di competenza:
-        #  1. La mia Sede attuale
-        #  2. Il mio Comitato
-        #  3. Le mie Sedi di competenza
-        sedi = self.request.user.persona.sedi_attuali() \
-            | self.request.user.persona.sedi_attuali().ottieni_comitati().espandi() \
-            | self.request.user.persona.sedi_deleghe_attuali(espandi=True, pubblici=True)
+        # Le mie Sedi di competenza
+        sedi = self.request.user.persona.sedi_deleghe_attuali(espandi=True, pubblici=True)
 
         self.choices = self.choices.filter(
             # 1. Appartenente a una delle sedi


### PR DESCRIPTION
## Motivazione

Vedi [JO-535](https://jira.gaia.cri.it/browse/JO-535)
Parte dell'anomalia riscontrata non è più presente. La problematica riguardo il fatto che la persona ha accesso in lettura a tutti i Volontari (da trasferire, estendere, etc.), delle sedi che sono fuori dalla sua competenza.


## Analisi

Nella costruzione della query vengono passate delle sedi sulle quali la persona non ha le competenze, la soluzione proposta evita il passaggio di queste sedi.


## Cambiamenti

L'utente vedrà, nell'autocompletamento, solo le persone appartenenti (o in estensione) ai comitati sui quali ha le competenze.


## Testing effettuato

Verifica autocompletamento direttamente nelle pagine delle pratiche: richiesta di trasferimento, estensione, riserva e provvedimento.

