### PR TITLE
JO-722: Modifiche per facilitare lo sviluppo (ed il testing) con PyCharm

### DIFF
--- a/.idea/runConfigurations/_jorvik__django__makemigrations.xml
+++ b/.idea/runConfigurations/_jorvik__django__makemigrations.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[jorvik] django: makemigrations" type="PythonConfigurationType" factoryName="Python">
+    <module name="jorvik" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="SKIP_DJANGO_COLLECSTATIC" value="1" />
+      <env name="SKIP_DJANGO_MIGRATE" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="manage.py" />
+    <option name="PARAMETERS" value="makemigrations --noinput" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/_jorvik__django__migrate.xml
+++ b/.idea/runConfigurations/_jorvik__django__migrate.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Creazione migrazioni (jorvik)" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="[jorvik] django: migrate" type="PythonConfigurationType" factoryName="Python">
+    <module name="jorvik" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="SKIP_DJANGO_COLLECSTATIC" value="1" />
       <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="SKIP_DJANGO_COLLECSTATIC" value="1" />
       <env name="SKIP_DJANGO_MIGRATE" value="1" />
     </envs>
     <option name="SDK_HOME" value="" />
@@ -12,10 +13,9 @@
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <module name="jorvik" />
-    <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="manage.py" />
-    <option name="PARAMETERS" value="makemigrations --noinput" />
+    <option name="PARAMETERS" value="migrate --noinput" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.idea/runConfigurations/_jorvik__django__runcrons.xml
+++ b/.idea/runConfigurations/_jorvik__django__runcrons.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Aggiornamento database (jorvik)" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="[jorvik] django: runcrons" type="PythonConfigurationType" factoryName="Python">
+    <module name="jorvik" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="SKIP_DJANGO_COLLECSTATIC" value="1" />
       <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="SKIP_DJANGO_COLLECSTATIC" value="1" />
       <env name="SKIP_DJANGO_MIGRATE" value="1" />
     </envs>
     <option name="SDK_HOME" value="" />
@@ -12,10 +13,9 @@
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <module name="jorvik" />
-    <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="manage.py" />
-    <option name="PARAMETERS" value="migrate --noinput" />
+    <option name="PARAMETERS" value="runcrons" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.idea/runConfigurations/_jorvik__runserver.xml
+++ b/.idea/runConfigurations/_jorvik__runserver.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[jorvik] runserver" type="Python.DjangoServer" factoryName="Django server">
+    <module name="jorvik" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="DJANGO_SETTINGS_MODULE" value="jorvik.settings" />
+    </envs>
+    <option name="SDK_HOME" value="docker-compose://[$PROJECT_DIR$/docker-compose.yml]:web/python" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="port" value="8000" />
+    <option name="host" value="0.0.0.0" />
+    <option name="additionalOptions" value="" />
+    <option name="browserUrl" value="" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="false" />
+    <option name="customRunCommand" value="" />
+    <method />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -51,11 +51,30 @@ Puoi trovare la **[Documentazione sul Wiki del progetto](https://github.com/Croc
 
 ### Requisiti
 
+#### Sviluppo
+
+Per lo sviluppo di Jorvik, potrai utilizzare i container già pronti che ti permetteranno
+di lavorare su Gaia senza la necessità di configurare manualmente un sistema di produzione.
+
+* **[Docker CE](https://www.docker.com/community-edition)** (o EE)
+* **[Python 3.4 e superiore](https://www.python.org/downloads/)**
+* **[Docker Compose](https://docs.docker.com/compose/install)**
+* **Linux, OS X o Windows 10**, ovvero qualunque OS che supporta i requisiti sopra elencati.
+
+
+#### Produzione
+
+Se vuoi configurare manualmente un sistema di produzione, puoi installare manualmente
+i requisiti necessari. A meno che tu abbia intenzione di mettere online un *fork* di Gaia
+su di un ambiente di produzione, questo è un metodo sconsigliato.
+
 * **[Python 3.4 e superiore](https://www.python.org/downloads/)** (es. `python3`)
 * **[PIP 3](https://www.python.org/downloads/)** (es. `pip3`)
+  * Usa quindi PIP per installare tutti i requisiti Python, che sono specificati [requirements.txt](requirements.txt).
 * **[PostgreSQL](http://www.postgresql.org/) 9.4+** con [PostGIS](http://postgis.net/))
 * **[GEOS](http://trac.osgeo.org/geos/)** (Geometry Engine Open Source)
-* **Linux**, Mac OS X e, probabilmente, Windows Server 2008 o 7 e superiori
+* **[Redis](https://redis.io/)**, o un altro broker supportato da [Celery](http://www.celeryproject.org/).
+* **Linux**.
 
 ### Ambiente di sviluppo
 

--- a/README.md
+++ b/README.md
@@ -65,38 +65,44 @@ Per la configurazione automatica dell'ambiente di sviluppo su **Linux, Mac OS X 
 1. **Scarica Docker CE** (o EE) da [docker.com](https://www.docker.com/community-edition),
 2. **Scarica Docker Compose** da [docker.com](https://docs.docker.com/compose/install/),
 3. **Scarica Jorvik** usando Git ([GitHub Desktop](https://desktop.github.com/) per Windows e Mac OS X, o da terminale come segue)
-
     ```bash
     $ git clone --recursive https://github.com/CroceRossaItaliana/jorvik
     ```
 4. **Aprire un terminale** (prompt dei Comandi su Windows) e accedere alla cartella dove risiede il codice appena scaricato.
-
    ```bash
    $ cd jorvik
    ```
-5. **Avvia Gaia** con Docker Compose (la prima volta potrebbe volerci un po')
-
-    ```bash
-    $ docker-compose up
-    ```
-
-   Questo avviera' i container necessari per lo sviluppo ed il testing di Gaia (web, database, pdf, selenium).
-
-6. **Installare PyCharm Professional** da [JetBrains](https://www.jetbrains.com/pycharm/). La licenza e' gratis per gli studenti. Contattaci se necessiti di una licenza per lavorare su Jorvik: abbiamo un numero limitato di licenze per i volontari, quindi approfitta del trial di 30 giorni per assicurarti di voler collaborare.
+5. **Installare PyCharm Professional** da [JetBrains](https://www.jetbrains.com/pycharm/). La licenza e' gratis per gli studenti. Contattaci se necessiti di una licenza per lavorare su Jorvik: abbiamo un numero limitato di licenze per i volontari, quindi approfitta del trial di 30 giorni per assicurarti di voler collaborare.
 6. **Configurare PyCharm per usare l'interprete del container Docker**:
-  * Preferenze > Progetto > Interprete > Aggiungi interprete remoto
-    ![image](https://cloud.githubusercontent.com/assets/621062/10762277/4da18088-7cbd-11e5-924e-a2737d7783e1.png)
+    * Preferenze > Progetto > Interprete > Aggiungi interprete remoto ([Vedi immagine](https://cloud.githubusercontent.com/assets/621062/10762277/4da18088-7cbd-11e5-924e-a2737d7783e1.png))
+    * Scegliere **"Docker-Compose"** e **`web`** come da immagine, e cliccare OK. ([Vedi immagine](https://user-images.githubusercontent.com/621062/34888028-7a95f13e-f7c0-11e7-9eaa-e6bad16c7f51.png))
+    * Assicurarsi che l'interprete "Remote Python 3.x Docker..." sia ora selezionato come predefinito per il progetto, quindi cliccare OK
+7. **Installa i dati di esempio**, scegliendo la configurazione `[jorvik] installa dati di esempio`** su PyCharm e premendo il taso "Run" ([Vedi immagine](https://user-images.githubusercontent.com/621062/39449785-eaa78f0a-4cc0-11e8-8e0d-a6034d53ad31.png)).
+8. **Avvia Jorvik** direttamente da PyCharm, scegliendo la configurazione `[jorvik] runserver`  ([Vedi immagine](https://user-images.githubusercontent.com/621062/39448999-c4bb7c40-4cbe-11e8-86be-4ba906ddc3ba.png)). Questo avvierà tutti i servizi necessari, utilizzando Docker Compose:
+    * `web`: Un server di sviluppo Django (`runserver`), che rileverà automaticamente le modifiche al codice e si riavvierà automaticamente;
+    * `db`: Un server di database PostgreSQL;
+    * `broker`, `celery`: Un broker (Redis) e un server per lo smistamento della coda di task (ad es., task di smistamento della posta);
+    * `pdf`: Un server per la generazione dei file PDF (Apache, PHP con DOMPDF);
+    * `selenium`: Un server Selenium con Firefox e un server VNC, per l'esecuzione dei test funzionali.
 
-  * Scegliere **"Docker-Compose"** e **`web`** come da immagine, e cliccare OK
-    ![image](https://user-images.githubusercontent.com/621062/34888028-7a95f13e-f7c0-11e7-9eaa-e6bad16c7f51.png)
+#### Altri strumenti di sviluppo
 
-  * Assicurarsi che l'interprete "Remote Python 3.x Docker..." sia ora selezionato come predefinito per il progetto, quindi cliccare OK
-
-6. **Usare il tasto "Run" su PyCharm** per controllare e avviare il server
-  ![image](https://cloud.githubusercontent.com/assets/621062/10762357/abcb3050-7cbd-11e5-9fdf-c08a0b439369.png)
-
+* **Avvia i task periodici** (cronjob) direttamente da Pycharm, scegliendo la configurazione `[jorvik] runcrons`.
+* **Esegui i test** (unitari e funzionali), scegliendo la configurazione `[jorvik] test` ([Vedi imagine](https://user-images.githubusercontent.com/621062/39449730-cbc0456e-4cc0-11e8-8b81-2fed10b9a028.png)).
+* **Connettiti al database** PostgreSQL utilizzando gli strumenti di PyCharm ([Vedi immagine](https://user-images.githubusercontent.com/621062/39449692-b3264c4c-4cc0-11e8-951f-53db3a4a1648.png)):
+  * Crea una nuove sorgente dati di tipo `PostgreSQL`,
+  * Scegli `localhost` come host e `5432` come porta,
+  * Utilizza `postgres` come username, senza alcuna password.
+* **Connettiti in desktop remoto per osservare l'esecuzione dei test funzionali** con Selenium, che vengono eseguiti in una istanza di Firefox.
+  * Utilizza il tuo client VNC preferito. Per esempio, su Linux, puoi usare `remmina`.
+  * Crea una connessione VNC, usando `localhost` come host, e porta `5900`.
+  * Se richiesto, utilizza `secret` come password.
 
 #### Docker Compose
+
+Se non utilizzi PyCharm, puoi utilizzare direttamente `docker-compose` da terminale
+per orchestrare i container dei vari servizi di Jorvik. Ecco un paio di comandi di
+esmepio.
 
 * **Configurare (primo avvio) e avviare i container di Gaia**
 
@@ -105,7 +111,6 @@ Per la configurazione automatica dell'ambiente di sviluppo su **Linux, Mac OS X 
     ```
 
 * **Arrestare Gaia**
-
     ```bash
     $ docker-compose stop
     ```
@@ -126,24 +131,24 @@ Per la configurazione automatica dell'ambiente di sviluppo su **Linux, Mac OS X 
     $ docker-compose exec web bash
     ```
 
-
-### Autenticazione a due fattori
+### Autenticazione a due fattori (2FA)
 
 Attualmente la piattaforma supporta la 2FA con:
 
  * Google Authenticator (e sistemi simili di OTP via QR Code)
  * Yubikey
  
-Per il setup di Yubikey si veda: http://django-two-factor-auth.readthedocs.io/en/stable/installation.html#yubikey-setup
+Per l'utilizzo di Yubikey, vedi la documentazione del modulo al seguente indirizzo:
+http://django-two-factor-auth.readthedocs.io/en/stable/installation.html#yubikey-setup
 
-Per attivare la 2FA per un utente è sufficiente:
+#### Attivare 2FA
 
- * Installare Google Authenticator sul proprio dispositivo mobile
- * Fare il login normalmente nel pannello admin (`/admin`)
- * Selezionare la voce "Two factor auth" nel menù admin
- * Seguire le istruzioni dello wizard
- * Selezionare "Token generator" fra le opzioni
- * Scansionare con Google Authenticator il codice QR mostrato
- * Inserire il token generato da Google Authenticator
- * Il dispositivo è adesso autenticato
+ 1. Installare Google Authenticator sul proprio dispositivo mobile
+ 2.  Fare il login normalmente nel pannello admin (`/admin`)
+ 3. Selezionare la voce "Two factor auth" nel menù admin
+ 4. Seguire le istruzioni dello wizard
+ 5. Selezionare "Token generator" fra le opzioni
+ 6. Scansionare con Google Authenticator il codice QR mostrato
+ 7. Inserire il token generato da Google Authenticator
+ 8. Il dispositivo è adesso configurato.
  

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Per la configurazione automatica dell'ambiente di sviluppo su **Linux, Mac OS X 
     * Scegliere **"Docker-Compose"** e **`web`** come da immagine, e cliccare OK. ([Vedi immagine](https://user-images.githubusercontent.com/621062/34888028-7a95f13e-f7c0-11e7-9eaa-e6bad16c7f51.png))
     * Assicurarsi che l'interprete "Remote Python 3.x Docker..." sia ora selezionato come predefinito per il progetto, quindi cliccare OK
 7. **Installa i dati di esempio**, scegliendo la configurazione `[jorvik] installa dati di esempio`** su PyCharm e premendo il taso "Run" ([Vedi immagine](https://user-images.githubusercontent.com/621062/39449785-eaa78f0a-4cc0-11e8-8e0d-a6034d53ad31.png)).
+    * Questo creerà una utenza di esempio che può essere usata per coadivare lo sviluppo, con le seguenti informazioni (e credenziali)
+        * Nome: Douglas Adams
+        * Delega: Presidente presso il Comitato di Gaia
+        * Email di accesso: `supporto@gaia.cri.it`
+        * Password: `42`
 8. **Avvia Jorvik** direttamente da PyCharm, scegliendo la configurazione `[jorvik] runserver`  ([Vedi immagine](https://user-images.githubusercontent.com/621062/39448999-c4bb7c40-4cbe-11e8-86be-4ba906ddc3ba.png)). Questo avvierà tutti i servizi necessari, utilizzando Docker Compose:
     * `web`: Un server di sviluppo Django (`runserver`), che rileverà automaticamente le modifiche al codice e si riavvierà automaticamente;
     * `db`: Un server di database PostgreSQL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   db:
     image: mdillon/postgis
+    ports:
+      - "5432:5432"
 
   web:
     build: .

--- a/scramble.py
+++ b/scramble.py
@@ -303,7 +303,7 @@ if args.esempio:
                         if not Utenza.objects.filter(email="supporto@gaia.cri.it").exists():
                             utenza = Utenza.objects.create(
                                 persona=persona, email="supporto@gaia.cri.it",
-                                password='pbkdf2_sha256$20000$ldk8aPLgcMXK$Cwni1ubmmKpzxO8xM75ZuwNR+k6ZHA5JTVxJFbgIzgo='
+                                password='pbkdf2_sha256$24000$vuuP6g3dJTyz$55k2PL/NCVk2j4T+cvA9pGeIkFRT2lxKMbjFLZeYR3Y='
                             )
                 elif indice == 1:
                     d = Delega.objects.create(persona=persona, tipo=UFFICIO_SOCI, oggetto=sede, inizio=poco_fa())


### PR DESCRIPTION
## Motivazione

Vedi [JO-722](https://jira.gaia.cri.it/browse/JO-722).

In seguito all'introduzione della configurazione Docker Compose, lo sviluppo e' stato reso molto piu' semplice, ma le configurazioni di PyCharm non sono state aggiornate di conseguenza. E' quindi necessario effettuare tutte le operazioni per orchestrare i container manualmente (ovvero da terminale, usando `docker-compose`).


## Analisi

E' stato necessario cambiare alcuni dei parametri delle configurazioni, per renderle funzionali con un interprete remoto su container Docker; sono state inoltre aggiunte delle nuove configurazioni.

## Cambiamenti

Configurando un interprete remoto di tipo "Docker Compose", come da istruzioni su README.md, e' ora possibile avviare Jorvik ed eseguire tutte le operazioni di sviluppo (inclusa l'esecuzione dei test, l'installazione dei dati di sviluppo, ecc.) dalla interfaccia PyCharm.

### Nuove configurazioni

![image](https://user-images.githubusercontent.com/621062/39451081-4faad408-4cc5-11e8-82b9-79dd52629f3b.png)

In aggiunta alle configurazioni PyCharm gia' esistenti:
- `[django] runserver`, che avvia un server di sviluppo Django (http://localhost:8000) e permette di avviare Gaia (il server si riavvia automaticamente quando rileva una modifica al codice);
- `[django] makemigations`, che puo' essere usato per creare le migrazioni quando vengono effettuate delle modifiche ai modelli
- `[django] migrate`, che applica le migrazioni non ancora applicate (se presenti) 
  - Nota: Questa operazione e' eseguita automaticamente da `[django] runserver`, non e' quindi generalmente necessario avviarla a meno che siano state create delle migrazioni e si vuole applicarle immediatamente, senza il riavvio del server Django;

Sono state aggiunte delle nuove configurazioni PyCharm:
- `[django] test` che permette di eseguire tutti i test, oppure solo una selezione, e fornisce a PyCharm tutte le informazioni sui risultati (vedi screenshot sottostante),
- `[django] runcrons` che esegue i task periodici, 
- `[django] installa dati di esempio` che, come dice il suo nome, installa i dati di esempio (senza necessita' di passare da una shell)

<img width="1266" alt="screen shot 2018-04-30 at 21 28 55" src="https://user-images.githubusercontent.com/621062/39451023-2c1f2840-4cc5-11e8-8157-3100324d3494.png">
 
### Dati di esempio

Oltre alla configurazione PyCharm per la creazione dei dati di esempio, ho modificato la password dell'account presidente creato automaticamente. Le credenziali sono le seguenti:
- Nome: Douglas Adams
- Email: `supporto@gaia.cri.it`
- Password: `42`

### Database

Ho modificato la configurazione in `docker-compose.yml` affinche' il container `db` esponga la porta `5342` (PostgreSQL via TCP). Questo permette la configurazione dello strumento "Database" di PyCharm per l'esplorazione del database, come da screenshot.

<img width="1097" alt="screen shot 2018-04-30 at 21 30 40" src="https://user-images.githubusercontent.com/621062/39450827-8bc5a6ee-4cc4-11e8-8da2-019ab3e7b4f0.png">

Ho inoltre modificato il file README.md con istruzioni per la configurazione di questo strumento.

### README.md

- Modificate istruzioni per configurare l'ambiente di sviluppo.
- Aggiunta una sezione per descrivere le nuove funzionalita' disponibili attraverso configurazioni PyCharm.
- Aggiunta sezione "Requisiti" semplificata per gli ambienti di sviluppo (tecnicamente, solo Docker e Docker Compose sono ora necessari).

## Limitazioni

N/A.

## Testing effettuato

Provate tutte le nuove configurazioni manualmente sul mio portatile, avente seguente configurazione:
- OS X 10.13.4
- PyCharm Professional 2018.1
- Docker CE 18.03.1-ce-mac65


/cc (per conoscenza) @acarmisciano @tvcitel @CroceRossaItaliana/sviluppo