### PR TITLE
raw id per invitante in admin corso base

### DIFF
--- a/formazione/admin.py
+++ b/formazione/admin.py
@@ -12,7 +12,7 @@ __author__ = 'alfioemanuele'
 
 RAW_ID_FIELDS_CORSOBASE = ['sede', 'locazione',]
 RAW_ID_FIELDS_PARTECIPAZIONECORSOBASE = ['persona', 'corso', 'destinazione',]
-RAW_ID_FIELDS_INVITOCORSOBASE = ['persona', 'corso',]
+RAW_ID_FIELDS_INVITOCORSOBASE = ['persona', 'corso', 'invitante',]
 RAW_ID_FIELDS_LEZIONECORSOBASE = ['corso',]
 RAW_ID_FIELDS_ASSENZACORSOBASE = ['lezione', 'persona', 'registrata_da',]
 RAW_ID_FIELDS_ASPIRANTE = ['persona', 'locazione',]


### PR DESCRIPTION
## Motivazione

Segnalata lentezza nell'apertura della vista di admin


## Analisi

Valutato un problema sistemistico. Assunto senza poter accedere al db che non ve ne fossero ho pensato di intervenire comunque con una ottimizzazione forse utile a prescindere. 
Non ho capito perché sia deteriorato rapidamente nel tempo perché l'ultima modifica che ha interessato la parte incriminata risale a ottobre 2016, forse l'aumento dell'utenza, forse merita maggiore analisi


## Cambiamenti

Modificato in admin la visualizzazione di `invitante` con un `raw fields`


## Testing effettuato

Aperta la pagina incriminata di admin su 3-4 corsi base.