### PR TITLE
JO-600: Corsi base: impossible iscrivere volontario dimesso

### DIFF
--- a/anagrafica/autocomplete_light_registry.py
+++ b/anagrafica/autocomplete_light_registry.py
@@ -128,12 +128,16 @@ class IscrivibiliCorsiAutocompletamento(PersonaAutocompletamento):
     }
 
     def choices_for_request(self):
+        volontari = self.model.objects.filter(
+            Q(Appartenenza.query_attuale(membro=Appartenenza.VOLONTARIO).via("appartenenze")))
+
         self.choices = self.choices.filter(
             Q(Appartenenza.query_attuale(membro=Appartenenza.SOSTENITORE).via("appartenenze")) |
             Q(aspirante__isnull=False)
         ).exclude(
-            Q(Appartenenza.query_attuale(membro=Appartenenza.VOLONTARIO).via("appartenenze"))
+            pk__in=volontari.values_list('pk', flat=True)
         ).order_by('nome', 'cognome', 'codice_fiscale').distinct('nome', 'cognome', 'codice_fiscale')
+
         return super(PersonaAutocompletamento, self).choices_for_request()
 
 


### PR DESCRIPTION
## Motivazione

Rif [JO-600](https://jira.gaia.cri.it/browse/JO-600)

## Analisi

query_attuale inserisce più di una clausola nel where, inserendo una Q con query attuale come exclude di queryset non fa quello che si vuole


## Cambiamenti

come workaround si è utilizzata la funzione values_list() con in che produce la query corretta.

## Limitazioni

utilizza una subselect e non fetcha effettivamente gli id
