### PR TITLE
aggiornamento libreria Pillow alla version 5.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==0.9.2
 django-autoslug==1.9.3
 django-mptt==0.8.7
 phonenumbers==8.8.9
-Pillow==3.2.0
+Pillow==5.2.0
 django-countries==3.3
 googlemaps==2.2
 lxml==4.1.1


### PR DESCRIPTION
## Motivazione

la versione corrente ha un bug di sicurezza critico, inoltre
con la version 3.2.0 in staging non si riuscivano a generare i barcode


## Analisi

Il sistema di check automatico di github ha segnalato una vulnerabilità nella libreria Pillow, inoltre la versione corrente impediva la corretta generazione dei barcode


## Cambiamenti

versione in requirements.txt

## Limitazioni

## Testing effettuato

Generazione tesserino (unica parte che utilizza pyBarcode che utilizza Pillow)
