### PR TITLE
Fix query Elenco "In Riserva"; URLs in templates; vari fix senza cambiamenti della funzionalità

### DIFF
--- a/anagrafica/admin.py
+++ b/anagrafica/admin.py
@@ -328,7 +328,7 @@ class AdminTrasferimento(ReadonlyAdminMixin, admin.ModelAdmin):
 @admin.register(Riserva)
 class AdminRiserva(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["persona__nome", "persona__cognome", "persona__codice_fiscale"]
-    list_display = ("persona",)
+    list_display = ("persona", 'inizio', 'fine', 'motivo',)
     list_filter = ("confermata", "ritirata", "creazione",)
     raw_id_fields = RAW_ID_FIELDS_RISERVA
     inlines = [InlineAutorizzazione]

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -2552,6 +2552,9 @@ class Riserva(ModelloSemplice, ConMarcaTemporale, ConStorico, ConProtocollo,
         )
         return pdf
 
+    def __str__(self):
+        return '%s (%s - %s)' % (self.persona, self.inizio, self.fine)
+
 
 class ProvvedimentoDisciplinare(ModelloSemplice, ConMarcaTemporale, ConProtocollo, ConStorico):
     AMMONIZIONE = "A"

--- a/anagrafica/templates/anagrafica_profilo_fototessera.html
+++ b/anagrafica/templates/anagrafica_profilo_fototessera.html
@@ -5,7 +5,6 @@
 
 {% block profilo_corpo %}
 <div class="row">
-
     <div class="col-md-8">
         <div class="panel panel-info">
             <div class="panel-heading">
@@ -57,20 +56,15 @@
                                     Nessuna fototessera caricata.
                                 </td>
                             </tr>
-
                         {% endfor %}
 
                     </tbody>
                 </table>
-
-
             </div>
         </div>
-
     </div>
 
     <div class="col-md-4">
-
     {% if puo_modificare %}
         <div class="panel panel-primary">
 
@@ -82,33 +76,18 @@
             </div>
 
             <div class="panel-body">
-
                 <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
-
-
                     {% bootstrap_form modulo %}
 
                     <p class="text-warning">
-                        <i class="fa fa-fw fa-warning"></i>
-                        Assicurati che rispetti le norme per le
-                        fototessere riportate <a target="_new"
-                            href="http://wiki.gaia.cri.it/index.php?title=Manuale_del_Volontario#Norme_generali">
-                        in questa pagina</a>.
+                        <i class="fa fa-fw fa-warning"></i> Assicurati che rispetti le norme per le fototessere riportate
+                        <a target="_new" href="https://wiki.gaia.cri.it/display/GAIA/Norme+da+rispettare+per+la+fototessera">in questa pagina</a>.
                     </p>
 
-                    <button type="submit" class="btn btn-block btn-primary">
-                        <i class="fa fa-fw fa-save"></i>
-                        Salva fototessera
-                    </button>
-
+                    <button type="submit" class="btn btn-block btn-primary"><i class="fa fa-fw fa-save"></i> Salva fototessera</button>
                 </form>
-
             </div>
-
-
-
-
         </div>
     </div>
     {% endif %}

--- a/anagrafica/templates/anagrafica_utente_fotografia_fototessera.html
+++ b/anagrafica/templates/anagrafica_utente_fotografia_fototessera.html
@@ -4,15 +4,10 @@
 {% load thumbnail %}
 
 {% block fotografia_corpo %}
-
     {% if me.fototessere.all.exists %}
         <div class="panel panel-info">
             <div class="panel-heading">
-                <h4 class="panel-title">
-                    <i class="fa fa-fw fa-list"></i>
-                    Storico richieste fototessere
-                </h4>
-
+                <h4 class="panel-title"><i class="fa fa-fw fa-list"></i> Storico richieste fototessere</h4>
             </div>
 
             <div class="panel-body">
@@ -25,16 +20,13 @@
                         <th>Inviata il</th>
                     </thead>
                     <tbody>
-
                         {% for t in me.fototessere.all %}
-
                             <tr class="
                                 {% if t == me.fototessera_attuale %}
                                     success
                                 {% elif t.esito == t.ESITO_PENDING %}
                                     warning
-                                {% endif %}
-                            ">
+                                {% endif %} ">
 
                                 <td class="grassetto">{{ t.esito }}</td>
                                 <td>
@@ -46,62 +38,34 @@
                                     </a>
                                 </td>
                                 <td>{{ t.creazione|date:"SHORT_DATETIME_FORMAT" }}</td>
-
-
-
                             </tr>
-
                         {% endfor %}
 
                     </tbody>
                 </table>
-
-
             </div>
         </div>
-
     {% endif %}
 
 
     <div class="panel panel-primary">
-
         <div class="panel-heading">
-            <h4 class="panel-title">
-                <i class="fa fa-fw fa-user"></i>
-                Fototessera
-            </h4>
+            <h4 class="panel-title"><i class="fa fa-fw fa-user"></i> Fototessera</h4>
         </div>
 
         <div class="panel-body">
-
             <form method="POST" enctype="multipart/form-data">
             {% csrf_token %}
-
-
                 {% bootstrap_form modulo_fototessera %}
-
                 <p class="text-warning">
                     <i class="fa fa-fw fa-warning"></i>
-                    La fototessera verr&agrave; sottoposta al tuo
-                    Ufficio Soci o Presidente per la verifica.
-                    Assicurati che rispetti le norme per le
-                    fototessere riportate <a target="_new"
-                        href="http://wiki.gaia.cri.it/index.php?title=Manuale_del_Volontario#Norme_generali">
-                    in questa pagina</a>.
+                    La fototessera verr&agrave; sottoposta al tuo Ufficio Soci o Presidente per la verifica. Assicurati che rispetti le norme per le fototessere riportate
+                    <a target="_new" href="https://wiki.gaia.cri.it/display/GAIA/Norme+da+rispettare+per+la+fototessera">in questa pagina</a>.
                 </p>
 
-                <button type="submit" class="btn btn-block btn-primary">
-                    <i class="fa fa-fw fa-save"></i>
-                    Salva fototessera
+                <button type="submit" class="btn btn-block btn-primary"><i class="fa fa-fw fa-save"></i>Salva fototessera
                 </button>
-
             </form>
-
         </div>
-
-
-
-
     </div>
-
 {% endblock %}

--- a/base/templates/base_autorizzazioni_inc_anagrafica_fototessera.html
+++ b/base/templates/base_autorizzazioni_inc_anagrafica_fototessera.html
@@ -2,20 +2,13 @@
 
 <a href="{{ richiesta.oggetto.file.url }}" target="_new" title="Vedi fototessera">
     {% thumbnail richiesta.oggetto.file "400x400" crop as im %}
-    <img src="{{ im.url }}" width="150" height="150"
-         align="left" alt="Anteprima fototessera"
-         style="margin-right: 8px; margin-bottom: 5px; border: 1px solid black;" />
+    <img src="{{ im.url }}" width="150" height="150" align="left" alt="Anteprima fototessera" style="margin-right: 8px; margin-bottom: 5px; border: 1px solid black;" />
 </a>
 
-<p>{{ richiesta.oggetto.persona.link|safe }} chiede l'approvazione della seguente fotografia
-    per l'uso come fototessera.
-    <a href="{{ richiesta.oggetto.file.url }}" target="_new" title="Vedi fototessera">
-        Vedi fotografia.
-    </a>
+<p>{{ richiesta.oggetto.persona.link|safe }} chiede l'approvazione della seguente fotografia per l'uso come fototessera.
+    <a href="{{ richiesta.oggetto.file.url }}" target="_new" title="Vedi fototessera">Vedi fotografia.</a>
 </p>
 
 <p>&Egrave; necessario assicurarsi che la fototessera rispetti le norme riportate
-    <a target="_new" href="http://wiki.gaia.cri.it/index.php?title=Manuale_del_Volontario#Norme_generali">
-        in questa pagina
-    </a>.</p>
-
+    <a target="_new" href="https://wiki.gaia.cri.it/display/GAIA/Norme+da+rispettare+per+la+fototessera">in questa pagina</a>.
+</p>

--- a/base/templates/base_informazioni.html
+++ b/base/templates/base_informazioni.html
@@ -68,7 +68,7 @@
         <div class="col-md-4">
             <h2><i class="fa fa-heart-o"></i> Aiuto</h2>
 
-            <p><a href="http://wiki.gaia.cri.it" class="btn btn-large btn-primary btn-block">
+            <p><a href="https://wiki.gaia.cri.it" class="btn btn-large btn-primary btn-block">
                 <i class="fa fa-question-circle"></i>
                 Hai già letto il nostro WIKI?
             </a></p>

--- a/base/templates/base_vuota.html
+++ b/base/templates/base_vuota.html
@@ -119,7 +119,7 @@
             <a href="/informazioni/verifica-tesserino/">
                 Verifica un tesserino CRI
             </a> |
-            <a href="http://wiki.gaia.cri.it/">
+            <a href="https://wiki.gaia.cri.it/">
                 Manuale d'uso
             </a>
           </div>

--- a/config/email.cnf.sample
+++ b/config/email.cnf.sample
@@ -9,6 +9,9 @@ backend = django.core.mail.backends.filebased.EmailBackend
 ##  SMTP: Invia tramite server SMTP.
 ;backend = django.core.mail.backends.smtp.EmailBackend
 
+##  Senza SMTP server. Scrive tutto in console
+;backend = django.core.mail.backends.console.EmailBackend
+
 # Configurazione
 
 # Attivare il log di debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 services:
-
   db:
     image: mdillon/postgis
     ports:
@@ -11,6 +10,7 @@ services:
     build: .
     volumes:
       - .:/code
+      - /tmp/media:/tmp/media
     ports:
       - "8000:8000"
     links:
@@ -39,12 +39,13 @@ services:
     build: .
     volumes:
       - .:/code
+      - /tmp/media:/tmp/media
     depends_on:
       - broker
     environment:
       - "SKIP_DJANGO_COLLECSTATIC=1"
       - "SKIP_DJANGO_MIGRATE=1"
-    command: "celery worker -b redis://broker -A jorvik -l info -Q coda_email_rischedula,coda_email_invio -B"
+    command: "celery worker -b redis://broker -A jorvik -l info -Q queue_monitoraggio,queue_formazione,coda_email_rischedula,coda_email_invio,queue_monitoraggio,periodic_ufficio_soci,shared_ufficio_soci -B"
 
   pdf:
     build: https://github.com/CroceRossaItaliana/gaia-dompdf.git#master

--- a/jorvik/celery.py
+++ b/jorvik/celery.py
@@ -18,8 +18,8 @@ app.conf.task_routes = {
     'posta.queue.rischedula_invii_falliti': {'queue': 'coda_email_rischedula'},
     'posta.tasks.invia_mail': {'queue': 'coda_email_invio'},
 
-    'ufficio_soci.tasks.delete_generated_elenco_soci_files': {'queue': 'periodic_ufficio_soci'},
-    'ufficio_soci.tasks.generate_elenco_soci_al_giorno': {'queue': 'shared_ufficio_soci'},
+    'ufficio_soci.tasks.delete_generated_elenco_files': {'queue': 'periodic_ufficio_soci'},
+    'ufficio_soci.tasks.generate_elenco': {'queue': 'shared_ufficio_soci'},
 
     'static_page.tasks.send_mail': {'queue': 'queue_monitoraggio'},
 }

--- a/static_page/templates/monitoraggio.html
+++ b/static_page/templates/monitoraggio.html
@@ -37,7 +37,7 @@
     <div>
       <p>Prima di iniziare il questionario, puoi consultare le istruzioni per la compilazione e il glossario ai link di seguito:
         <a href="/page/m-glossario/" target="_blank">glossario</a>, <a href="/page/m-istruzioni/" target="_blank">istruzioni</a><br>
-        Per una agevole raccolta dei dati, puoi <a href="https://datafiles.gaia.cri.it/media/filer_public/c2/bb/c2bb495b-66db-4690-b45b-3d627f528646/form_monitoraggio_2019.pdf">consultare il pdf</a> delle domande prima di procedere alla compilazione del questionario.
+        Per una agevole raccolta dei dati, puoi <a target="_blank" href="https://datafiles.gaia.cri.it/media/filer_public/c2/bb/c2bb495b-66db-4690-b45b-3d627f528646/form_monitoraggio_2019.pdf">consultare il pdf</a> delle domande prima di procedere alla compilazione del questionario.
       </p>
     </div>
 

--- a/static_page/views.py
+++ b/static_page/views.py
@@ -62,15 +62,15 @@ def monitoraggio(request, me):
     context['user_id'] = typeform.get_user_pk
     context['all_forms_are_completed'] = typeform.all_forms_are_completed
 
-    # Get celery_task_id
-    # TODO: ajax polling task is ready
-    prefix = typeform.CELERY_TASK_PREFIX
-    message_storage = get_messages(request)
-    if len(message_storage) > 0:
-        for line, msg in enumerate(message_storage):
-            if msg.message.startswith(prefix):
-                context['celery_task_id'] = msg.message.replace(prefix, '').strip()
-                del message_storage._loaded_messages[line]
+    # # Get celery_task_id
+    # # TODO: ajax polling task is ready
+    # prefix = typeform.CELERY_TASK_PREFIX
+    # message_storage = get_messages(request)
+    # if len(message_storage) > 0:
+    #     for line, msg in enumerate(message_storage):
+    #         if msg.message.startswith(prefix):
+    #             context['celery_task_id'] = msg.message.replace(prefix, '').strip()
+    #             del message_storage._loaded_messages[line]
 
     return 'monitoraggio.html', context
 

--- a/ufficio_soci/elenchi.py
+++ b/ufficio_soci/elenchi.py
@@ -600,15 +600,15 @@ class ElencoInRiserva(ElencoVistaSoci):
         ).distinct('cognome', 'nome', 'codice_fiscale')
 
     def excel_colonne(self):
-        def riserva(p, att):
-            ris = Riserva.objects.filter(
-                persona=p.id,
-            ).order_by('-creazione')
-            if ris:
-                return getattr(ris.first(), att)
+        def riserva(p, attr):
+            query = Riserva.objects.filter(
+                Q(fine__gte=timezone.now()) | Q(fine__isnull=True),
+                persona=p.id)
+            if query:
+                return getattr(query.last(), attr)
             return ''
 
-        return super(ElencoInRiserva, self).excel_colonne() + (
+        return super().excel_colonne() + (
             ("Data inizio", lambda p: riserva(p, 'inizio')),
             ("Data fine", lambda p: riserva(p, 'fine')),
             ("Motivazioni", lambda p: riserva(p, 'motivo'))

--- a/ufficio_soci/reports.py
+++ b/ufficio_soci/reports.py
@@ -14,7 +14,7 @@ from celery import uuid
 
 from anagrafica.permessi.costanti import GESTIONE_SOCI
 from .models import Quota, Tesseramento, ReportElenco
-from .tasks import generate_elenco_soci_al_giorno
+from .tasks import generate_elenco
 from . import elenchi
 
 
@@ -350,7 +350,7 @@ class ReportElencoSoci:
         report_db.save()
 
         # Partire celery task e reindirizza user sulla pagina "Report Elenco"
-        task = generate_elenco_soci_al_giorno.apply_async(
+        task = generate_elenco.apply_async(
             (self.celery_params, report_db.id),
             task_id=task_uuid)
 

--- a/ufficio_soci/tasks.py
+++ b/ufficio_soci/tasks.py
@@ -7,7 +7,7 @@ from ufficio_soci.models import ReportElenco
 
 
 @shared_task(bind=True)
-def generate_elenco_soci_al_giorno(self, *args):
+def generate_elenco(self, *args):
     from .reports import ReportElencoSoci
 
     report = ReportElencoSoci(from_celery=True)
@@ -15,7 +15,7 @@ def generate_elenco_soci_al_giorno(self, *args):
 
 
 @periodic_task(run_every=timedelta(seconds=86400))  # 24h
-def delete_generated_elenco_soci_files():
+def delete_generated_elenco_files():
     delta = datetime.today() - timedelta(hours=24)
 
     files_to_delete = ReportElenco.objects.filter(creazione__lt=delta)


### PR DESCRIPTION
- Fissati urls nei templates (email di PieroS.@18/04/2019)
- Fissata **query** in ufficio_soci/elenchi "In Riserva" (GAIA-62)
- Modificati **nomi** dei celery tasks di ufficio_soci
- Modifiche al monitoraggio (ripristinate ca02bf715ef379b4656842cdaa9b017c6054d3c2)
- Aggiunto **console e-mail backend** (per mostrare le mail inviate in console) in config/email.cnf e altre piccole modifiche.