### PR TITLE
Set django-cors-middleware version 1.3.1 in requirements.txt

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -7,6 +7,7 @@
 # before starting the Django development server.
 #
 
+
 if [ "$SKIP_ALL" ]
 then
     SKIP_REQUIREMENTS_CHECK=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ freezegun==0.3.9
 unicodecsv==0.14.1
 celery[redis]==4.1.1
 django-oauth-toolkit==0.12.0
-django-cors-middleware
+django-cors-middleware==1.3.1
 djangorestframework==3.6
 xhtml2pdf
 xlwt==1.3.0


### PR DESCRIPTION
Impostata la versione di **django-cors-middleware** in requirements.txt
L'ultima versione di questa libreria non supporta Django 1.9.