### PR TITLE
Fix cron approvazione automatica

### DIFF
--- a/base/admin.py
+++ b/base/admin.py
@@ -41,10 +41,11 @@ class AdminLocazione(ReadonlyAdminMixin, admin.ModelAdmin):
 class AdminAutorizzazione(ReadonlyAdminMixin, admin.ModelAdmin):
     search_fields = ["richiedente__nome", "richiedente__cognome", "richiedente__codice_fiscale",
                      "firmatario__nome", "firmatario__cognome", "firmatario__codice_fiscale", ]
-    list_display = ("richiedente", "firmatario", "concessa", "necessaria", "progressivo",
-                    "oggetto_tipo", "oggetto_id",
-                    "destinatario_ruolo", "destinatario_oggetto_tipo", "destinatario_oggetto_id")
-    list_filter = ("necessaria", "concessa", "destinatario_oggetto_tipo",)
+    list_display = ("richiedente", "firmatario", "concessa", 'automatica',
+                    "necessaria", "progressivo", "oggetto_tipo", "oggetto_id",
+                    "destinatario_ruolo",
+                    "destinatario_oggetto_tipo", "destinatario_oggetto_id")
+    list_filter = ("necessaria", "concessa", 'automatica', "destinatario_oggetto_tipo",)
     raw_id_fields = ("richiedente", "firmatario", )
 
 

--- a/base/cron.py
+++ b/base/cron.py
@@ -1,7 +1,7 @@
 from django_cron import CronJobBase, Schedule
 
-from base.models import Allegato, Autorizzazione
 from formazione.models import Aspirante
+from .models import Allegato, Autorizzazione
 
 
 class CronCancellaFileScaduti(CronJobBase):

--- a/base/models.py
+++ b/base/models.py
@@ -1,4 +1,5 @@
 import os
+from dateutil.relativedelta import relativedelta
 
 from collections import defaultdict
 from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKey
@@ -356,7 +357,7 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
 
     @classmethod
     def gestisci_automatiche(cls):
-        delta = now() - relativedelta(months=6)
+        delta = now() - relativedelta(months=1)
         qs = cls.objects.filter(concessa__isnull=True, scadenza__isnull=False,
                                 scadenza__gte=delta, scadenza__lte=now())
         da_negare = qs.filter(tipo_gestione=cls.NG_AUTO)

--- a/base/models.py
+++ b/base/models.py
@@ -188,7 +188,7 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
             raise ValueError("Il modulo richiesto per l'accettazione non e' stato completato correttamente.")
 
         if not self.oggetto:
-            print('L\'autorizzazione {} risulta non avere oggetti collegati'.format(self.pk))
+            print("L'autorizzazione %s risulta non avere oggetti collegati" % self.pk)
             return
 
         self.concessa = concedi
@@ -336,31 +336,46 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
         }
         self._invia_notifica(modello, oggetto, auto, aggiunte_corpo=aggiunte_corpo)
 
+    @property
+    def is_valid_per_approvazione_automatica(self):
+        if self.oggetto is None:
+            return False  # Saltare Autorizzazione senza <oggetto>
+        else:
+            return self.scadenza \
+                   and self.concessa is None \
+                   and self.scadenza < now() \
+                   and not self.oggetto.ritirata
+
     def controlla_concedi_automatico(self):
-        if self.scadenza and self.concessa is None and self.scadenza < now() and not self.oggetto.ritirata:
+        if self.is_valid_per_approvazione_automatica:
             self.concedi(auto=True)
 
     def controlla_nega_automatico(self):
-        if self.scadenza and self.concessa is None and self.scadenza < now() and not self.oggetto.ritirata:
+        if self.is_valid_per_approvazione_automatica:
             self.nega(auto=True)
-
-    def automatizza(self, concedi=None, scadenza=None):
-        if concedi and not self.oggetto.ritirata:
-            self.tipo_gestione = concedi
-            self.scadenza = calcola_scadenza(scadenza)
-            self.save()
 
     @classmethod
     def gestisci_automatiche(cls):
-        base = cls.objects.filter(
-            concessa__isnull=True, scadenza__isnull=False, scadenza__lte=now()
-        )
-        da_negare = base.filter(tipo_gestione=cls.NG_AUTO)
-        da_approvare = base.filter(tipo_gestione=cls.AP_AUTO)
+        delta = now() - relativedelta(months=6)
+        qs = cls.objects.filter(concessa__isnull=True, scadenza__isnull=False,
+                                scadenza__gte=delta, scadenza__lte=now())
+        da_negare = qs.filter(tipo_gestione=cls.NG_AUTO)
+        da_approvare = qs.filter(tipo_gestione=cls.AP_AUTO)
+
         for autorizzazione in da_negare:
             autorizzazione.controlla_nega_automatico()
         for autorizzazione in da_approvare:
             autorizzazione.controlla_concedi_automatico()
+
+    def automatizza(self, concedi=None, scadenza=None):
+        if not self.oggetto:
+            print('Autorizzazione %s non ha oggetto collegato' % autorizzazione.pk)
+            return
+
+        if concedi and not self.oggetto.ritirata:
+            self.tipo_gestione = concedi
+            self.scadenza = calcola_scadenza(scadenza)
+            self.save()
 
     @classmethod
     def notifiche_richieste_in_attesa(cls):
@@ -370,9 +385,7 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
         oggetto = "Richieste in attesa di approvazione"
         modello = "email_richieste_pending.html"
 
-        in_attesa = cls.objects.filter(
-            concessa__isnull=True
-        )
+        in_attesa = cls.objects.filter(concessa__isnull=True)
         trasferimenti = in_attesa.filter(oggetto_tipo=ContentType.objects.get_for_model(Trasferimento))
         estensioni = in_attesa.filter(oggetto_tipo=ContentType.objects.get_for_model(Estensione))
         trasferimenti_manuali = trasferimenti.filter(scadenza__isnull=True, tipo_gestione=Autorizzazione.MANUALE)
@@ -385,7 +398,7 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
         persone = dict()
         for autorizzazione in autorizzazioni:
             if not autorizzazione.oggetto:
-                print('autorizzazione {} non ha oggetto collegato'.format(autorizzazione.pk))
+                print('Autorizzazione %s non ha oggetto collegato' % autorizzazione.pk)
                 continue
             if autorizzazione.oggetto and not autorizzazione.oggetto.ritirata and not autorizzazione.oggetto.confermata:
                 destinatari = cls.espandi_notifiche(autorizzazione.destinatario_oggetto, [], True, True)
@@ -417,6 +430,12 @@ class Autorizzazione(ModelloSemplice, ConMarcaTemporale):
                 corpo=corpo,
                 destinatari=[persona['persona']]
             )
+
+    def __str__(self):
+        if self.oggetto:
+            return str(self.oggetto)
+        else:
+            return super().__str__()
 
 
 class Log(ModelloSemplice, ConMarcaTemporale):
@@ -808,6 +827,7 @@ class ConAutorizzazioni(models.Model):
         """
         return ModuloMotivoNegazione
 
+
 class ConScadenzaPulizia(models.Model):
     """
     Aggiunge un attributo DateTimeField scadenza.
@@ -900,6 +920,7 @@ class Token(ModelloSemplice, ConMarcaTemporale):
         permissions = (
             ("view_token", "Can view token"),
         )
+
 
 class Allegato(ConMarcaTemporale, ConScadenzaPulizia, ModelloSemplice):
     """


### PR DESCRIPTION
Ogni tanto il queryset delle autorizzazione da approvare/negare automaticamente (con Cron) aveva un oggetto senza <oggetto>, quindi il campo <ritirata> del <oggetto> non era possibile leggere.
Il task non riusciva mai a concludersi con successo (tutti django_cron tasks con is_success=False).