### PR TITLE
fix libreria django-opt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,6 @@ djangorestframework==3.6
 xhtml2pdf
 xlwt==1.3.0
 django-oidc-provider==0.6.2
+django-otp==0.6.0
 https://github.com/emfcamp/python-barcode/archive/0.7.zip # pyBarcode==0.7
 https://github.com/nephila/django-filer/archive/296fa6170a3749532b85ceb033eeae0fb839e9a6.zip


### PR DESCRIPTION
fix requirements, la dipendenza django-opt di django-otp-yubikey si è aggiornata in automatico. Creava problemi nell'avvio di GAIA l'ho riportata alla eversion 0.6.0