### PR TITLE
Formazione

### DIFF
--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -676,15 +676,25 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
         from formazione.models import PartecipazioneCorsoBase, CorsoBase
         return PartecipazioneCorsoBase.con_esito_ok().filter(persona=self, corso__stato=CorsoBase.ATTIVO).first()
 
-    def richieste_di_partecipazione(self):
-        """ Restituisce richieste di partecipazione confermate e in attesa """
+    def richieste_di_partecipazione(self, corso_stato=None):
+        """ Restituisce richieste di partecipazione ai corsi confermate e in attesa """
         from formazione.models import PartecipazioneCorsoBase, CorsoBase
+        if corso_stato is None:
+            corso_stato = [CorsoBase.ATTIVO,]
 
         confirmed = PartecipazioneCorsoBase.con_esito_ok()
         pending = PartecipazioneCorsoBase.con_esito_pending()
         requests_to_courses = confirmed | pending
 
-        return requests_to_courses.filter(persona=self, corso__stato=CorsoBase.ATTIVO)
+        return requests_to_courses.filter(persona=self, corso__stato__in=corso_stato)
+
+    @property
+    def corsi_frequentati(self):
+        from formazione.models import CorsoBase
+        return CorsoBase.objects.filter(
+            pk__in=[i.corso.pk for i in self.richieste_di_partecipazione(
+                    corso_stato=[CorsoBase.TERMINATO,])]
+        ).order_by('-data_esame')
 
     @property
     def volontario_da_meno_di_un_anno(self):

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -450,9 +450,7 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
 
     @property
     def volontario(self, **kwargs):
-        """
-        Controlla se membro volontario
-        """
+        """ Controlla se membro volontario """
         return self.membro(Appartenenza.VOLONTARIO, **kwargs)
 
     @property

--- a/anagrafica/models.py
+++ b/anagrafica/models.py
@@ -688,11 +688,15 @@ class Persona(ModelloSemplice, ConMarcaTemporale, ConAllegati, ConVecchioID):
 
     @property
     def corsi_frequentati(self):
-        from formazione.models import CorsoBase
-        return CorsoBase.objects.filter(
-            pk__in=[i.corso.pk for i in self.richieste_di_partecipazione(
-                    corso_stato=[CorsoBase.TERMINATO,])]
-        ).order_by('-data_esame')
+        from formazione.models import PartecipazioneCorsoBase, CorsoBase
+
+        confirmed = PartecipazioneCorsoBase.con_esito_ok().filter(persona=self,
+                                                                  corso__stato=CorsoBase.TERMINATO)
+        if not confirmed:
+            return CorsoBase.objects.none()
+
+        corsi = CorsoBase.objects.filter(pk__in=[i.corso.pk for i in confirmed])
+        return corsi.order_by('-data_esame')
 
     @property
     def volontario_da_meno_di_un_anno(self):

--- a/anagrafica/templates/anagrafica_utente_curriculum.html
+++ b/anagrafica/templates/anagrafica_utente_curriculum.html
@@ -103,7 +103,7 @@
                                         <p class="grassetto">
                                             {{ t.titolo.nome }}
 
-                                            {% if t.is_course_title and not t.is_expired_course_title %}
+                                            {% if t.is_course_title %} <!-- and not t.is_expired_course_title -->
                                                 <br><a href="{% url 'aspirante:report_schede' t.corso_partecipazione.corso.pk %}?download_single_attestato={{t.pk}}">Scarica attestato</a>
                                             {% endif %}
                                         </p>
@@ -115,10 +115,10 @@
                                             </span>
 
                                         {% elif t.is_expired_course_title %}
-                                            <span class="text-danger">
+                                            <!-- <span class="text-danger">
                                                 <i class="fa fa-fw fa-clock-o"></i>
                                                 Scaduto titolo del corso
-                                            </span>
+                                            </span> -->
 
                                         {% elif t.esito == t.ESITO_OK %}
                                             <span class="text-success">
@@ -151,9 +151,9 @@
                                         {% endif %}
 
                                         {% if t.data_scadenza %}
-                                            <i class="fa fa-fw text-muted fa-clock-o"></i>
+                                            <!-- <i class="fa fa-fw text-muted fa-clock-o"></i>
                                             {{ t.data_scadenza|date:"SHORT_DATE_FORMAT" }}
-                                            <br />
+                                            <br /> -->
                                         {% endif %}
 
                                         {% if t.codice %}
@@ -166,8 +166,7 @@
                                     <td>
                                         <a href="/utente/curriculum/{{ t.pk }}/cancella/"
                                            data-conferma="Sei sicuro/a di voler rimuovere {{ t.titolo.nome }} dal tuo curriculum?"
-                                           class="btn btn-xs btn-danger" title="Rimuovi dal curriculum">
-                                            <i class="fa fa-trash"></i>
+                                           class="btn btn-xs btn-danger" title="Rimuovi dal curriculum"> <i class="fa fa-trash"></i>
                                         </a>
                                     </td>
                                 </tr>
@@ -176,22 +175,15 @@
                                 <tr class="alert alert-warning">
                                     <td colspan="4">
                                         <h4><i class="fa fa-fw fa-info-circle"></i> Nessun dato inserito</h4>
-                                        <p>Se hai un/una {{ tipo_display }}, usa il modulo
-                                            a sinistra per inserirlo.</p>
+                                        <p>Se hai un/una {{ tipo_display }}, usa il modulo a sinistra per inserirlo.</p>
                                     </td>
                                 </tr>
-
                             {% endfor %}
                         </tbody>
                     </table>
-
                 </div>
             </div>
-
         </div>
-
-
-
     </div>
 
 {% endblock %}

--- a/anagrafica/templates/anagrafica_utente_curriculum.html
+++ b/anagrafica/templates/anagrafica_utente_curriculum.html
@@ -164,10 +164,12 @@
 
                                     </td>
                                     <td>
-                                        <a href="/utente/curriculum/{{ t.pk }}/cancella/"
-                                           data-conferma="Sei sicuro/a di voler rimuovere {{ t.titolo.nome }} dal tuo curriculum?"
-                                           class="btn btn-xs btn-danger" title="Rimuovi dal curriculum"> <i class="fa fa-trash"></i>
-                                        </a>
+                                        {% if not t.is_course_title %}
+                                            <a href="/utente/curriculum/{{ t.pk }}/cancella/"
+                                               data-conferma="Sei sicuro/a di voler rimuovere {{ t.titolo.nome }} dal tuo curriculum?"
+                                               class="btn btn-xs btn-danger" title="Rimuovi dal curriculum"> <i class="fa fa-trash"></i>
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
 

--- a/anagrafica/viste.py
+++ b/anagrafica/viste.py
@@ -1200,7 +1200,7 @@ def utente_curriculum(request, me, tipo=None):
                 )
             return redirect("/utente/curriculum/%s/?inserimento=ok" % (tipo,))
 
-    titoli = me.titoli_personali.all().filter(titolo__tipo=tipo).order_by('-data_scadenza')
+    titoli = me.titoli_personali.all().filter(titolo__tipo=tipo).order_by('data_scadenza')
 
     contesto = {
         "tipo": tipo,

--- a/base/geo.py
+++ b/base/geo.py
@@ -240,7 +240,13 @@ class ConGeolocalizzazioneRaggio(ConGeolocalizzazione):
         Filtra una ricerca, per gli elementi nel raggio di questo elemento.
         :return: La ricerca filtrata
         """
+        from formazione.models import CorsoBase
+
         if not self.locazione:
+            # Check per restituire <QuerySet> dello stesso tipo di oggetto <ricerca>
+            if ricerca.model is CorsoBase:
+                return CorsoBase.objects.none()
+
             return self.__class__.objects.none()
 
         q = ricerca.filter(locazione__geo__distance_lte=(self.locazione.geo, D(km=self.raggio)))

--- a/curriculum/admin.py
+++ b/curriculum/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.contrib.postgres.fields import JSONField
+
+from prettyjson import PrettyJSONWidget
 
 from base.admin import InlineAutorizzazione
 from gruppi.readonly_admin import ReadonlyAdminMixin
@@ -12,6 +15,9 @@ class AdminTitolo(ReadonlyAdminMixin, admin.ModelAdmin):
         'inseribile_in_autonomia', 'expires_after', 'scheda_prevede_esame',)
     list_filter = ('is_active', 'cdf_livello', 'area', "tipo", "richiede_conferma",
         "inseribile_in_autonomia", 'goal__unit_reference', 'scheda_prevede_esame',)
+    formfield_overrides = {
+        JSONField: {'widget': PrettyJSONWidget}
+    }
 
     def goal_obbiettivo_stragetico(self, obj):
         return obj.goal.unit_reference if hasattr(obj.goal,

--- a/curriculum/cron.py
+++ b/curriculum/cron.py
@@ -1,29 +1,29 @@
-from django_cron import CronJobBase, Schedule
-from posta.models import Messaggio
-from jorvik.settings import DEFAULT_FROM_EMAIL
-from .models import TitoloPersonale
+# from django_cron import CronJobBase, Schedule
+# from posta.models import Messaggio
+# from jorvik.settings import DEFAULT_FROM_EMAIL
+# from .models import TitoloPersonale
 
 
-class CronCheckExpiredCourseTitles(CronJobBase):
-    RUN_EVERY_HOURS = 23
-    RUN_EVERY_MINS = RUN_EVERY_HOURS * 60
-
-    schedule = Schedule(run_every_mins=RUN_EVERY_MINS)
-    code = 'curriculum.check_expired_course_titles'
-
-    def do(self):
-        titles = TitoloPersonale.get_expired_course_titles()
-        if titles:
-            for title in titles:
-                persona = title.persona
-                email = persona.utenza.email
-                Messaggio.costruisci_e_accoda(
-                    oggetto="Il tuo titolo %s è scaduto." % title.titolo.nome,
-                    modello="email_expired_course_titolo_personale.html",
-                    corpo={
-                        'title': title,
-                        'persona': persona,
-                    },
-                    destinatari=[persona],
-                )
-            print('Sono stati notificati degli utenti con dei titoli del corso scaduti.')
+# class CronCheckExpiredCourseTitles(CronJobBase):
+#     RUN_EVERY_HOURS = 23
+#     RUN_EVERY_MINS = RUN_EVERY_HOURS * 60
+#
+#     schedule = Schedule(run_every_mins=RUN_EVERY_MINS)
+#     code = 'curriculum.check_expired_course_titles'
+#
+#     def do(self):
+#         titles = TitoloPersonale.get_expired_course_titles()
+#         if titles:
+#             for title in titles:
+#                 persona = title.persona
+#                 email = persona.utenza.email
+#                 Messaggio.costruisci_e_accoda(
+#                     oggetto="Il tuo titolo %s è scaduto." % title.titolo.nome,
+#                     modello="email_expired_course_titolo_personale.html",
+#                     corpo={
+#                         'title': title,
+#                         'persona': persona,
+#                     },
+#                     destinatari=[persona],
+#                 )
+#             print('Sono stati notificati degli utenti con dei titoli del corso scaduti.')

--- a/curriculum/models.py
+++ b/curriculum/models.py
@@ -88,6 +88,11 @@ class Titolo(ModelloSemplice, ConVecchioID):
 
     @property
     def expires_after_timedelta(self):
+        #
+        # Aggiornato con GAIA-184: attualmente i titoli CRI non hanno una
+        # scadenza, quindi questo metodo non fa niente da nessuna parte.
+        #
+
         from datetime import timedelta
         days = self.expires_after if self.expires_after else 0
         if self.is_titolo_corso_base:
@@ -111,6 +116,9 @@ class Titolo(ModelloSemplice, ConVecchioID):
             return 10, 30
 
         return CorsoBase.MIN_PARTECIPANTI, CorsoBase.MAX_PARTECIPANTI
+
+    def corsi(self, **kwargs):
+        return self.corsobase_set.all().filter(**kwargs)
 
     def __str__(self):
         return str(self.nome)
@@ -202,7 +210,7 @@ class TitoloPersonale(ModelloSemplice, ConMarcaTemporale, ConAutorizzazioni):
             return True
         return False
         """
-        return False
+        return False  # OBS: GAIA-184
 
     @classmethod
     def get_expired_course_titles(cls):

--- a/formazione/forms.py
+++ b/formazione/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import ModelForm, modelformset_factory
@@ -171,11 +173,12 @@ class ModuloModificaLezione(ModelForm):
             lezione_ore = self.instance.lezione_ore
             if lezione_ore:
                 duration = fine-inizio
-                days, seconds = duration.days, duration.seconds
-                hours = days * 24 + seconds // 3600
-                if hours > lezione_ore:
+                # days, seconds = duration.days, duration.seconds
+                # hours = days * 24 + seconds // 3600
+                # hours = datetime.timedelta(hours=hours)
+                if duration.seconds > lezione_ore.seconds:
                     self.add_error('fine', 'La durata della lezione non può essere '
-                       'maggiore della durata impostata nella scheda per questa lezione (%s ore).' % lezione_ore)
+                       'maggiore della durata impostata nella scheda per questa lezione (%s).' % lezione_ore)
 
         self.clean_docente_fields()
 

--- a/formazione/models.py
+++ b/formazione/models.py
@@ -188,18 +188,19 @@ class CorsoBase(Corso, ConVecchioID, ConPDF):
             if persona.ha_aspirante:
                 return self.NON_PUOI_SEI_ASPIRANTE
 
-        # Controllo estensioni
-        if self.extension_type in [CorsoBase.EXT_MIA_SEDE, CorsoBase.EXT_LVL_REGIONALE]:
-            if not self.persona_verifica_estensioni(persona):
-                return self.NON_PUOI_ISCRIVERTI_ESTENSIONI_NON_COINCIDONO
+        # Non fare la verifica per gli aspiranti (non hanno appartenenze)
+        if not persona.ha_aspirante:
+            # Controllo estensioni
+            if self.extension_type in [CorsoBase.EXT_MIA_SEDE, CorsoBase.EXT_LVL_REGIONALE]:
+                if not self.persona_verifica_estensioni(persona):
+                    return self.NON_PUOI_ISCRIVERTI_ESTENSIONI_NON_COINCIDONO
 
         # if not persona.has_required_titles_for_course(course=self):
         #     return self.NON_PUOI_ISCRIVERTI_NON_HAI_TITOLI
 
         # Verifica presenza dei documenti personali aggiornati
         if persona.personal_identity_documents():
-            esito_verifica = self.persona_verifica_documenti_personali(
-                persona)
+            esito_verifica = self.persona_verifica_documenti_personali(persona)
             if esito_verifica:
                 return esito_verifica
         else:

--- a/formazione/models.py
+++ b/formazione/models.py
@@ -986,10 +986,10 @@ class CorsoBase(Corso, ConVecchioID, ConPDF):
 
         from curriculum.models import TitoloPersonale
 
-        if self.corso_vecchio:
-            data_scadenza = None
-        else:
-            data_scadenza = timezone.now() + self.titolo_cri.expires_after_timedelta
+        # if self.corso_vecchio:
+        #     data_scadenza = None
+        # else:
+        #     data_scadenza = timezone.now() + self.titolo_cri.expires_after_timedelta
 
         objs = [
             TitoloPersonale(
@@ -998,7 +998,7 @@ class CorsoBase(Corso, ConVecchioID, ConPDF):
                 persona=p.persona,
                 certificato_da=self.get_firmatario,
                 data_ottenimento=kwargs.get('data_ottenimento'),
-                data_scadenza=data_scadenza,
+                data_scadenza=None,  # OBS: GAIA-184
                 is_course_title=True,
                 corso_partecipazione=p
             )

--- a/formazione/models.py
+++ b/formazione/models.py
@@ -1171,22 +1171,19 @@ class CorsoBase(Corso, ConVecchioID, ConPDF):
         return False
 
     def can_activate(self, me):
-        if me.is_presidente:
-            """ All'presidente deve sparire la sezione dell'attivazione corso se:
-            - ha caricato delibera
-            - ha impostato estensioni (/aspirante/corso-base/<id>/estensioni/)
-            - ha nominato almeno un direttore
-            """
-            has_delibera = self.delibera_file is not None
-            has_extension = self.has_extensions()
-            has_directors = self.direttori_corso().count() > 0
-            is_all_true = has_delibera, has_extension, has_directors
+        if me.is_presidente or (me.is_presidente and me in self.direttori_corso()):
+            has_delibera = self.delibera_file is not None  # ha caricato delibera
+            # has_extension = self.has_extensions()
+            has_directors = self.direttori_corso().count() > 0  # ha nominato almeno un direttore
+            is_all_true = has_delibera, has_directors  # has_extension,
 
-            # # Deve riapparire se: il direttore ha inserito la descrizione
+            # Deve riapparire se: il direttore ha inserito la descrizione
             # if self.descrizione:
             #     return True
-            # else:
-            return True if False in is_all_true else False
+
+            if False in is_all_true:
+                return False
+            return True
         else:
             """ Direttori del corso vedono sempre la sezione invece """
             return True

--- a/formazione/templates/aspirante_corsi.html
+++ b/formazione/templates/aspirante_corsi.html
@@ -11,16 +11,14 @@
         .aspirante-corsi-table thead tr th {vertical-align:top;}
     </style>
 
-
     <h2><i class="fa fa-fw fa-home"></i> Corsi {% if me.volontario %}attivi{%else%}nelle tue vicinanze{%endif%}</h2>
 
     {% if me.aspirante %}
-    <div class="alert alert-info">
-        <i class="fa fa-fw fa-info-circle"></i>
-        Questo &egrave; un elenco dei Corsi nel raggio di {{ me.aspirante.raggio|default:"0" }} km
-        da {{ me.aspirante.locazione|default:"n/a" }}. Puoi modificare la posizione dal menu "Aspirante" > "Impostazioni".
-    </div>
-    {%endif%}
+        <div class="alert alert-info">
+            <i class="fa fa-fw fa-info-circle"></i> Questo &egrave; un elenco dei Corsi nel raggio di {{ me.aspirante.raggio|default:"0" }} km
+            da {{ me.aspirante.locazione|default:"n/a" }}. Puoi modificare la posizione dal menu "Aspirante" > "Impostazioni".
+        </div>
+    {% endif %}
 
     <table class="aspirante-corsi-table table table-striped table-bordered">
         <thead>
@@ -31,7 +29,7 @@
             </tr>
         </thead>
 
-        {% for corso in corsi %}
+        {% for corso in corsi_attivi %}
             <tr>
                 <td>
                     <strong>{{ corso.link|safe }}</strong><br />
@@ -71,4 +69,45 @@
             </tr>
         {% endfor %}
     </table>
+
+    {% if corsi_frequentati %}
+    <h2><i class="fa fa-fw fa-home"></i> Corsi frequentati</h2>
+    <table class="aspirante-corsi-table table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th style="width:55%;">Corso e Sede</th>
+                <th style="width:25%;">Informazioni</th>
+            </tr>
+        </thead>
+
+        {% for corso in corsi_frequentati %}
+            <tr>
+                <td>
+                    <strong>{{ corso.link|safe }}</strong><br />
+                    <i class="fa fa-fw fa-home"></i>
+                        {{ corso.sede.link|safe }}<br />
+                    {% if corso.locazione %}
+                        <i class="fa fa-fw fa-map-marker"></i>
+                        {{ corso.locazione }}
+                    {% endif %}
+                </td>
+                <td>
+                    <i class="fa fa-fw fa-calendar"></i>
+                        {% if not corso.iniziato %}
+                            Inizia: {{ corso.data_inizio|date:"SHORT_DATETIME_FORMAT" }}
+                        {% else %}
+                            <span class="bg-danger">Iniziato: {{ corso.data_inizio|date:"SHORT_DATETIME_FORMAT" }}</span>
+                        {% endif %}
+                        <br />
+                    <i class="fa fa-fw fa-calendar"></i> Esami: {{ corso.data_esame|date:"SHORT_DATETIME_FORMAT" }}<br />
+                    <i class="fa fa-fw fa-user"></i> Direttore ({{ corso.deleghe.count }}):
+                        {% for d in corso.deleghe.all %}
+                            {{ d.persona.link|safe }}
+                        {% endfor %}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+
 {% endblock %}

--- a/formazione/templates/aspirante_corso_base_scheda_informazioni.html
+++ b/formazione/templates/aspirante_corso_base_scheda_informazioni.html
@@ -4,6 +4,7 @@
 {% load social %}
 {% load humanize %}
 {% load bootstrap3 %}
+{% load formazione_templatetags %}
 
 {% block scheda_contenuto %}
 
@@ -246,7 +247,7 @@
                                 {{ lezione.inizio.date|naturalday:"DATE_FORMAT" }}, {{ lezione.inizio.time|date:"TIME_FORMAT" }}
                             </span>
                             {% if lezione.fine %} &mdash; {{ lezione.fine.time|date:"TIME_FORMAT" }}{% endif %}
-                            {% if lezione.lezione_ore and not lezione.divisa %}(<strong>{{ lezione.lezione_ore }}</strong> ore){% endif %}
+                            {% if lezione.lezione_ore and not lezione.divisa %}(<strong>{% lezione_durata lezione %}</strong>){% endif %}
                             {% if lezione.luogo %}<br>{{ lezione.luogo }}{% endif %}
                             {% if lezione.docente %}<br>{{ lezione.docente.cognome }} {{ lezione.docente.nome }}{% endif %}
                         </td>

--- a/formazione/templates/aspirante_corso_base_scheda_informazioni.html
+++ b/formazione/templates/aspirante_corso_base_scheda_informazioni.html
@@ -101,8 +101,6 @@
             Non puoi partecipare perchè non hai titoli necessari.
         {% elif puoi_partecipare == corso.NON_PUOI_ISCRIVERTI_ESTENSIONI_NON_COINCIDONO %}
             Non puoi partecipare perchè non hai tutti i requisiti.
-
-
         {% elif puoi_partecipare == corso.NON_HAI_CARICATO_DOCUMENTI_PERSONALI %}
             Per iscriverti a questo corso inserisci la copia di un documento di riconoscimento in corso di validità (CDI, Passaporto o Patente Civile).
 

--- a/formazione/templates/aspirante_corso_base_scheda_lezioni.html
+++ b/formazione/templates/aspirante_corso_base_scheda_lezioni.html
@@ -9,6 +9,7 @@
 
 {% block scheda_contenuto %}
 <style>
+  .scheda-lezione-non-revisionata {color:red;}
   .esonero-text {font-size: 12px; padding: 4px 6px;}
   .lezione-scheda-text {display:block; margin-bottom:15px; text-align:center; color:red; font-weight:bold;}
   .toggle-bg {background-color: #c00 !important; color: #fff;}
@@ -34,7 +35,7 @@
                       {{ lezione.inizio.date|naturalday:"DATE_FORMAT" }}, {{ lezione.inizio.time|date:"TIME_FORMAT" }}
                   </span>
                   {% if lezione.fine %} &mdash; {{ lezione.fine.time|date:"TIME_FORMAT" }}{% endif %}
-                  {% if lezione.lezione_ore and not lezione.divisa %}(<strong>{{ lezione.lezione_ore }}</strong> ore){% endif %}
+                  {% if lezione.lezione_ore and not lezione.divisa %}(<strong>{% lezione_durata lezione %}</strong> ore){% endif %}
                 </div>
               </div>
             </td>

--- a/formazione/templates/formazione_albo_inc_elenchi_persone_titoli.html
+++ b/formazione/templates/formazione_albo_inc_elenchi_persone_titoli.html
@@ -18,9 +18,10 @@
 
       {% for title in titoli.lista %}
         {{ title.titolo|truncatechars:80 }} -
-        <span style="{% if title.is_expired_course_title %}background-color:red;color:white;padding:1px 2px;{% endif %}">
-          {{ title.data_scadenza|date:"d/m/Y" }}
-        </span><br>
+
+        <!-- <span style="{% if title.is_expired_course_title %}background-color:red;color:white;padding:1px 2px;{% endif %}"></span> -->
+        <span>{{ title.data_scadenza|date:"d/m/Y" }}</span><br>
+
       {% empty %}
         {% if not titoli.num_of_titles %}
           <p style="text-align:center;">0 risultati</p>

--- a/formazione/templates/pdf_corso_attestato.html
+++ b/formazione/templates/pdf_corso_attestato.html
@@ -133,8 +133,7 @@
 				<div class="page-splitter right">
 					<div class="page-content-section">
 						<h3>Tipologia verifica finale:</h3>
-						<p>La verifica individuale di fine corso dovrà prevedere:<br>
-							Test scritto per valutare le conoscenze acquisite; Un colloquio individuale volto all’autovalutazione, all’analisi condivisa delle performance e della partecipazione durante il percorso formativo, alla condivisione del vissuto personale e di gruppo; Una breve prova pratica con simulazione di intervento didattico e gestione d’aula; Tirocinio in affiancamento a personale esperto in didattica nelle prime attività da trainer (almeno 5 affiancamenti) e nella prima direzione di corso.</p>
+						<p>{{ corso.titolo_cri.scheda_competenze_in_uscita }}</p>
 					</div>
 					<div class="page-content-section" style="margin-top:250px;">
 						{% if corso.tipo == Corso.BASE %}

--- a/formazione/templatetags/formazione_templatetags.py
+++ b/formazione/templatetags/formazione_templatetags.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -146,3 +148,23 @@ def verbale_indirizzo(corso):
                                                          locazione.comune,
                                                          locazione.via,
                                                          locazione.civico)
+
+@register.simple_tag
+def lezione_durata(lezione):
+    durata = None
+
+    if lezione.non_revisionata:
+        durata = lezione.lezione_ore
+    else:
+        inizio, fine = lezione.inizio, lezione.fine
+        if inizio and fine:
+            durata = lezione.fine - lezione.inizio
+            durata = datetime.timedelta(seconds=durata.seconds)
+        else:
+            durata = lezione.lezione_ore
+
+    if durata:
+        splitted = str(durata).split(':')
+        if splitted:
+            return "%s ore %s min" % tuple(splitted[:2])
+    return ''

--- a/formazione/viste.py
+++ b/formazione/viste.py
@@ -954,11 +954,15 @@ def aspirante_corsi(request, me):
         # Unisci 2 categorie di corsi
         corsi = corsi_confermati | corsi_da_partecipare | corsi_estensione_mia_appartenenze
 
+    corsi_frequentati = me.corsi_frequentati
+    corsi_attivi = corsi.exclude(pk__in=corsi_frequentati.values_list('pk', flat=True))
+
     context = {
-        'corsi':  corsi.order_by('data_inizio',),
+        'corsi_attivi': corsi_attivi.order_by('data_inizio',),
+        'corsi_frequentati': corsi_frequentati,
         'puo_creare': True if me.ha_permesso(GESTIONE_CORSI_SEDE) else False
     }
-    return 'aspirante_corsi_base.html', context
+    return 'aspirante_corsi.html', context
 
 
 @pagina_privata

--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     'filer',
     'ckeditor',
     'ckeditor_filebrowser_filer',
+    'prettyjson',
 
     'django_otp',
     'django_otp.plugins.otp_static',

--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -95,7 +95,7 @@ CRON_CLASSES = [
     "base.cron.PulisciAspirantiVolontari",
     "anagrafica.cron.CronReportComitati",
     "centrale_operativa.cron.CronCancellaCoturniInvalidi",
-    'curriculum.cron.CronCheckExpiredCourseTitles',
+    # 'curriculum.cron.CronCheckExpiredCourseTitles',
 ]
 
 # Classi middleware (intercetta & computa)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ django_compressor==2.0
 django-oidc-provider==0.6.2
 django-loginas==0.3.1
 django-otp==0.6.0
+django-prettyjson==0.4.1
 djangorestframework==3.6
 Markdown==2.6
 phonenumbers==8.8.9


### PR DESCRIPTION
- GAIA-156 (rielaborata lettura valore minuti dalla scheda lezioni e altre modifiche in merito)
- GAIA-170 (aggiungere corsi frequentati in Elenco corsi)
- GAIA-184
  -- togliere fine qualifica (titolo cri) e le relative verifiche/scadenze
  -- non visualizzare il link cancella titolo (anagrafica_utente_curriculum.html)
- GAIA-190 (queryset error perchè nel_raggio() restituiva empty queryset di un altro tipo)
- GAIA-193 (possibilità di attivare corso se presidente e direttore sono la stessa persona)
- GAIA-196 (nuovo attestato mostra testo dal campo Titolo.scheda_competenze_in_uscita)

**No Task:**
- libreria django-prettyjson per facilitare il lavoro con il campo Titolo.scheda_lezioni (su Django-admin)
